### PR TITLE
 Add unified MCP endpoint with ServiceNow + Databricks demo  

### DIFF
--- a/cmd/uniproxy/main.go
+++ b/cmd/uniproxy/main.go
@@ -635,6 +635,10 @@ func RunUniproxy() {
 	logging.ProxyLogger.Info("AdapterHandler created: %v", adapterHandler != nil)
 	logging.ProxyLogger.Success("AdapterService and AdapterHandler initialized")
 
+	// Initialize UnifiedMCPHandler for aggregated MCP endpoint
+	unifiedMCPHandler := handlers.NewUnifiedMCPHandler(adapterService, userGroupService)
+	logging.ProxyLogger.Info("UnifiedMCPHandler created: %v", unifiedMCPHandler != nil)
+
 	// Adapter handlers are now used directly in Gin routes
 
 	// Helper function to convert Gin context to standard HTTP handler
@@ -797,6 +801,10 @@ func RunUniproxy() {
 				handleMCPPromptGet(c, adapterStore, stdioToHTTPAdapter, remoteHTTPPlugin, sessionStore)
 			})
 		}
+
+		// Unified MCP endpoint - aggregates all adapters into a single MCP interface
+		logging.ProxyLogger.Info("Setting up unified MCP endpoint")
+		v1.Any("/mcp", ginToHTTPHandler(unifiedMCPHandler.HandleUnifiedMCP))
 
 		// Registry routes
 		registry := v1.Group("/registry")

--- a/examples/servicenow-databricks-demo/.env.example
+++ b/examples/servicenow-databricks-demo/.env.example
@@ -1,0 +1,53 @@
+# ServiceNow + Databricks Demo Configuration
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+
+# =============================================================================
+# ServiceNow Configuration
+# =============================================================================
+SERVICENOW_INSTANCE_URL=https://devXXXXX.service-now.com
+SERVICENOW_AUTH_METHOD=pat
+
+# Personal Access Token (recommended for Zurich+)
+SERVICENOW_PAT=your-personal-access-token
+
+# Or OAuth 2.0 (for production)
+# SERVICENOW_CLIENT_ID=your-client-id
+# SERVICENOW_CLIENT_SECRET=your-client-secret
+
+# Or Basic Auth (legacy)
+# SERVICENOW_USERNAME=admin
+# SERVICENOW_PASSWORD=your-password
+
+# Set to false for live data
+SERVICENOW_MOCK_MODE=false
+
+# =============================================================================
+# Databricks Configuration
+# =============================================================================
+DATABRICKS_HOST=https://dbc-xxxxx.cloud.databricks.com
+DATABRICKS_TOKEN=dapi-xxxxxxxxxxxxxxxx
+
+# SQL Warehouse ID (required for analytics queries)
+# Find at: Databricks UI > SQL Warehouses > Click warehouse > Copy ID from URL
+DATABRICKS_WAREHOUSE_ID=your-warehouse-id
+
+# Catalog and schema for analytics tables
+DATABRICKS_CATALOG=main
+DATABRICKS_SCHEMA=analytics
+
+# Set to false for live data
+DATABRICKS_MOCK_MODE=false
+
+# =============================================================================
+# Universal Proxy Configuration
+# =============================================================================
+PROXY_URL=http://localhost:8911
+
+# MCP server endpoints (when running locally outside k8s)
+# SERVICENOW_ENDPOINT=http://localhost:8000/mcp
+# DATABRICKS_ENDPOINT=http://localhost:8001/mcp
+
+# MCP server endpoints (when running in k8s)
+SERVICENOW_ENDPOINT=http://servicenow-mcp.servicenow-databricks-demo.svc.cluster.local:8000/mcp
+DATABRICKS_ENDPOINT=http://databricks-mcp.servicenow-databricks-demo.svc.cluster.local:8001/mcp

--- a/examples/servicenow-databricks-demo/.gitignore
+++ b/examples/servicenow-databricks-demo/.gitignore
@@ -1,0 +1,27 @@
+# Demo script (contains customer-specific content)
+DEMO_SCRIPT.md
+
+# Environment files with secrets
+.env
+.env.local
+.env.*.local
+
+# Don't ignore the example
+!.env.example
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/examples/servicenow-databricks-demo/PRODUCTION_SETUP.md
+++ b/examples/servicenow-databricks-demo/PRODUCTION_SETUP.md
@@ -1,0 +1,252 @@
+# Production Demo Setup Guide
+
+This guide walks through setting up the ServiceNow + Databricks demo with **live data** and **Claude Code** as the AI client.
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│ Claude Code │────▶│ Universal Proxy  │────▶│ ServiceNow      │
+│   (MCP)     │     │  localhost:8911  │     │ (your instance) │
+└─────────────┘     │                  │     └─────────────────┘
+                    │                  │     ┌─────────────────┐
+                    │                  │────▶│ Databricks      │
+                    └──────────────────┘     │ (your workspace)│
+                                             └─────────────────┘
+```
+
+## Prerequisites
+
+- ServiceNow developer instance (Zurich or later for PAT support)
+- Databricks workspace with SQL Warehouse access
+- Claude Code CLI installed
+- Universal Proxy running locally or in Kubernetes
+
+---
+
+## Step 1: ServiceNow Setup
+
+### 1.1 Create a Personal Access Token (PAT)
+
+1. Log into your ServiceNow instance
+2. Navigate to: **System OAuth > Personal Access Tokens**
+3. Click **New**
+4. Set:
+   - **Name**: `mcp-demo-token`
+   - **Expiration**: Set appropriate date
+5. Click **Generate Token**
+6. **Copy and save the token** (you won't see it again)
+
+### 1.2 Load Demo Incidents
+
+Run this script to create sample incidents in ServiceNow:
+
+```bash
+# Set your credentials
+export SERVICENOW_INSTANCE_URL="https://devXXXXX.service-now.com"
+export SERVICENOW_PAT="your-personal-access-token"
+
+# Run the data loader
+./scripts/load-servicenow-data.sh
+```
+
+This creates incidents that correlate with Databricks errors:
+- INC0010001: Database connection timeout (Critical)
+- INC0010002: Databricks cluster scaling failure (High)
+- INC0010003: ETL pipeline data quality alert (Medium)
+
+---
+
+## Step 2: Databricks Setup
+
+### 2.1 Get Your Credentials
+
+1. Log into your Databricks workspace
+2. Click your profile icon → **Settings**
+3. Go to **Developer** → **Access Tokens**
+4. Click **Generate New Token**
+5. Copy the token (starts with `dapi`)
+6. Note your workspace URL (e.g., `https://dbc-xxxxx.cloud.databricks.com`)
+
+### 2.2 Create Analytics Tables
+
+Run this notebook or SQL to create the demo tables:
+
+```bash
+# Set your credentials
+export DATABRICKS_HOST="https://dbc-xxxxx.cloud.databricks.com"
+export DATABRICKS_TOKEN="dapi-xxxxxxxx"
+
+# Run the data loader
+./scripts/load-databricks-data.sh
+```
+
+This creates:
+- `main.analytics.error_metrics_hourly` - Error rate data
+- `main.analytics.system_events` - System event log
+- `main.analytics.system_health` - Health metrics
+
+---
+
+## Step 3: Configure MCP Servers for Real Mode
+
+### 3.1 Update Kubernetes Secrets
+
+```bash
+# Create secrets for ServiceNow
+kubectl create secret generic servicenow-credentials \
+  --namespace servicenow-databricks-demo \
+  --from-literal=SERVICENOW_INSTANCE_URL="https://devXXXXX.service-now.com" \
+  --from-literal=SERVICENOW_PAT="your-pat-token" \
+  --from-literal=SERVICENOW_MOCK_MODE="false" \
+  --from-literal=SERVICENOW_AUTH_METHOD="pat"
+
+# Create secrets for Databricks
+kubectl create secret generic databricks-credentials \
+  --namespace servicenow-databricks-demo \
+  --from-literal=DATABRICKS_HOST="https://dbc-xxxxx.cloud.databricks.com" \
+  --from-literal=DATABRICKS_TOKEN="dapi-xxxxxxxx" \
+  --from-literal=DATABRICKS_MOCK_MODE="false"
+```
+
+### 3.2 Update Deployments to Use Secrets
+
+Apply the production overlay:
+
+```bash
+kubectl apply -k k8s/overlays/production/
+```
+
+Or update the deployments manually to reference the secrets.
+
+---
+
+## Step 4: Configure Claude Code
+
+### 4.1 Create MCP Configuration
+
+Create or edit `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "servicenow": {
+      "type": "http",
+      "url": "http://localhost:8911/api/v1/adapters/servicenow/mcp",
+      "headers": {
+        "X-User-ID": "demo-user"
+      }
+    },
+    "databricks": {
+      "type": "http",
+      "url": "http://localhost:8911/api/v1/adapters/databricks/mcp",
+      "headers": {
+        "X-User-ID": "demo-user"
+      }
+    }
+  }
+}
+```
+
+### 4.2 Verify Configuration
+
+```bash
+# Check Claude Code sees the MCP servers
+claude mcp list
+
+# Test a tool call
+claude mcp call servicenow search_incidents '{"limit": 3}'
+```
+
+---
+
+## Step 5: Run the Demo
+
+### 5.1 Start the Infrastructure
+
+```bash
+# Option A: All in Kubernetes
+kubectl apply -k k8s/
+
+# Port forward the proxy
+kubectl port-forward -n servicenow-databricks-demo svc/suse-ai-proxy 8911:8911
+
+# Register adapters
+./scripts/register-adapters.sh
+```
+
+### 5.2 Demo Conversation with Claude Code
+
+Start Claude Code and try these prompts:
+
+```
+You: "What critical incidents are currently open in ServiceNow?"
+
+You: "For incident INC0010001, can you check Databricks for related
+     errors around the same time?"
+
+You: "What's the current system health in Databricks? Are there any
+     metrics that might explain the incident?"
+
+You: "Based on the ServiceNow incident and Databricks data, what do
+     you think is the root cause?"
+```
+
+---
+
+## Environment Variables Reference
+
+### ServiceNow MCP Server
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `SERVICENOW_MOCK_MODE` | Use mock data (true/false) | `false` |
+| `SERVICENOW_INSTANCE_URL` | Your instance URL | `https://devXXXXX.service-now.com` |
+| `SERVICENOW_AUTH_METHOD` | Auth type: `oauth`, `pat`, `basic` | `pat` |
+| `SERVICENOW_PAT` | Personal Access Token | `xxxxxxxx` |
+| `SERVICENOW_CLIENT_ID` | OAuth client ID (if using OAuth) | |
+| `SERVICENOW_CLIENT_SECRET` | OAuth client secret (if using OAuth) | |
+
+### Databricks MCP Server
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DATABRICKS_MOCK_MODE` | Use mock data (true/false) | `false` |
+| `DATABRICKS_HOST` | Workspace URL | `https://dbc-xxx.cloud.databricks.com` |
+| `DATABRICKS_TOKEN` | Personal access token | `dapi-xxxxxxxx` |
+
+---
+
+## Troubleshooting
+
+### Claude Code can't connect to MCP servers
+
+1. Check proxy is running: `curl http://localhost:8911/health`
+2. Check adapters are registered: `curl -H "X-User-ID: admin" http://localhost:8911/api/v1/adapters`
+3. Test adapter directly:
+   ```bash
+   curl -X POST http://localhost:8911/api/v1/adapters/servicenow/mcp \
+     -H "Content-Type: application/json" \
+     -H "X-User-ID: demo-user" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+   ```
+
+### ServiceNow authentication fails
+
+1. Verify PAT hasn't expired
+2. Check instance URL doesn't have trailing slash
+3. Test directly:
+   ```bash
+   curl -H "Authorization: Bearer YOUR_PAT" \
+     "https://devXXXXX.service-now.com/api/now/table/incident?sysparm_limit=1"
+   ```
+
+### Databricks authentication fails
+
+1. Verify token is valid
+2. Check workspace URL
+3. Test directly:
+   ```bash
+   curl -H "Authorization: Bearer dapi-xxxxx" \
+     "https://dbc-xxxxx.cloud.databricks.com/api/2.0/clusters/list"
+   ```

--- a/examples/servicenow-databricks-demo/README.md
+++ b/examples/servicenow-databricks-demo/README.md
@@ -1,0 +1,312 @@
+# ServiceNow + Databricks Incident Correlation Demo
+
+This demo showcases how the **SUSE AI Universal Proxy** enables AI assistants to work with enterprise systems through a unified MCP endpoint.
+
+## Demo Scenario
+
+An AI assistant investigates a production incident by:
+
+1. **Discovering** high-priority incidents in ServiceNow
+2. **Correlating** with error metrics from Databricks
+3. **Identifying** the root cause (database connection pool exhaustion)
+4. **Mapping** affected configuration items
+5. **Updating** the incident with findings
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      AI Assistant (Claude Code)                  │
+└───────────────────────────┬─────────────────────────────────────┘
+                            │ MCP Protocol (single connection)
+                            ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  SUSE AI Universal Proxy                         │
+│                                                                  │
+│  Unified Endpoint: /api/v1/mcp                                  │
+│  - Aggregates tools from all adapters                           │
+│  - Tool naming: adapter__toolname                               │
+│  - Routes calls to correct backend                              │
+│                                                                  │
+│  Adapters:                                                       │
+│  ├── servicenow (17 tools)                                      │
+│  └── databricks (10 tools)                                      │
+└───────────┬───────────────────────────────────┬─────────────────┘
+            │                                   │
+            ▼                                   ▼
+┌───────────────────────┐           ┌───────────────────────┐
+│   ServiceNow MCP      │           │   Databricks MCP      │
+│   (Pod: port 8000)    │           │   (Pod: port 8001)    │
+└───────────┬───────────┘           └───────────┬───────────┘
+            │                                   │
+            ▼                                   ▼
+    ServiceNow API                      Databricks API
+    (Real Instance)                     (Real Workspace)
+```
+
+## Prerequisites
+
+- **Rancher Desktop** with Kubernetes enabled
+- **kubectl** configured to connect to Rancher Desktop
+- **curl** and **jq** for testing
+
+## Quick Start
+
+### 1. Deploy to Kubernetes
+
+```bash
+cd examples/servicenow-databricks-demo
+
+# Make scripts executable
+chmod +x scripts/*.sh
+
+# Deploy to Rancher Desktop's k3s cluster
+kubectl apply -k k8s/overlays/production/
+```
+
+### 2. Start Port Forward
+
+```bash
+kubectl port-forward -n servicenow-databricks-demo svc/suse-ai-proxy 8911:8911 &
+```
+
+### 3. Register Adapters
+
+```bash
+./scripts/register-adapters.sh
+```
+
+### 4. Load Demo Data
+
+```bash
+./scripts/load-servicenow-data.sh --reset
+```
+
+### 5. Connect Claude Code
+
+```bash
+# Add the unified MCP endpoint
+claude mcp add suse-ai-proxy http://localhost:8911/api/v1/mcp \
+  --transport http \
+  -H "X-User-ID: admin"
+
+# Verify connection
+claude
+# Then type /mcp to see connected tools
+```
+
+### 6. Try Demo Queries
+
+In Claude Code:
+```
+List incidents with correlation_id SUSE-AI-DEMO
+```
+
+```
+Get details for incident INC0010014
+```
+
+```
+Check Databricks error metrics for the last 6 hours
+```
+
+## Tool Naming Convention
+
+Tools are prefixed with the adapter name:
+- `servicenow__search_incidents`
+- `servicenow__get_incident`
+- `servicenow__update_incident`
+- `databricks__get_error_metrics`
+- `databricks__execute_sql`
+
+## Demo Data
+
+Demo incidents are tagged with `correlation_id=SUSE-AI-DEMO` for easy filtering.
+
+To reset demo data:
+```bash
+./scripts/load-servicenow-data.sh --reset
+```
+
+## Real Mode Setup
+
+### ServiceNow Configuration
+
+Create a `.env` file:
+```bash
+SERVICENOW_MOCK_MODE=false
+SERVICENOW_INSTANCE_URL=https://devXXXXX.service-now.com
+SERVICENOW_AUTH_METHOD=basic
+SERVICENOW_USERNAME=your_username
+SERVICENOW_PASSWORD=your_password
+```
+
+### Databricks Configuration
+
+Add to `.env`:
+```bash
+DATABRICKS_MOCK_MODE=false
+DATABRICKS_HOST=https://dbc-xxxxx.cloud.databricks.com
+DATABRICKS_TOKEN=dapi-xxxxxxxx
+DATABRICKS_WAREHOUSE_ID=your_warehouse_id
+```
+
+Then redeploy:
+```bash
+kubectl apply -k k8s/overlays/production/
+```
+
+## Directory Structure
+
+```
+servicenow-databricks-demo/
+├── README.md                     # This file
+├── DEMO_SCRIPT.md               # Customer demo walkthrough
+├── PRODUCTION_SETUP.md          # Production deployment guide
+├── docker-compose.yaml          # Alternative: Docker Compose deployment
+├── claude-code-mcp-config.json  # Example Claude Code MCP config
+├── servers/
+│   ├── servicenow_mcp_server.py # ServiceNow MCP server
+│   ├── databricks_mcp_server.py # Databricks MCP server
+│   ├── Dockerfile.servicenow
+│   └── Dockerfile.databricks
+├── k8s/
+│   ├── kustomization.yaml       # Base kustomization
+│   ├── namespace.yaml
+│   ├── configmap.yaml
+│   ├── proxy-deployment.yaml
+│   ├── servicenow-deployment.yaml
+│   ├── databricks-deployment.yaml
+│   └── overlays/
+│       ├── mock/                # Mock mode overlay
+│       ├── real/                # Real mode with secrets
+│       └── production/          # Production overlay
+└── scripts/
+    ├── register-adapters.sh     # Register MCP servers with proxy
+    ├── load-servicenow-data.sh  # Load/reset demo incidents
+    ├── load-databricks-data.sh  # Load demo analytics data
+    ├── setup-rancher-desktop.sh # Initial setup
+    └── run-demo.sh              # Scripted demo
+```
+
+## MCP Tools Reference
+
+### ServiceNow Tools
+
+| Tool | Description |
+|------|-------------|
+| `servicenow__search_incidents` | Search by priority, state, category, correlation_id |
+| `servicenow__get_incident` | Get incident details by number |
+| `servicenow__create_incident` | Create a new incident |
+| `servicenow__update_incident` | Update incident (state, work notes) |
+| `servicenow__get_related_cis` | Get related configuration items |
+| `servicenow__search_cmdb` | Search the CMDB |
+| `servicenow__get_incident_metrics` | Get aggregate metrics |
+
+### Databricks Tools
+
+| Tool | Description |
+|------|-------------|
+| `databricks__list_clusters` | List clusters and status |
+| `databricks__get_cluster` | Get cluster details |
+| `databricks__list_jobs` | List Databricks jobs |
+| `databricks__get_job_runs` | Get job run history |
+| `databricks__execute_sql` | Execute SQL queries |
+| `databricks__get_error_metrics` | Get error rates and metrics |
+| `databricks__get_system_health` | Get system health dashboard |
+| `databricks__correlate_events` | Correlate events across systems |
+
+## Testing via curl
+
+### Through Unified Endpoint (Recommended)
+
+```bash
+# List all tools
+curl -X POST http://localhost:8911/api/v1/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-User-ID: admin" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}'
+
+# Search demo incidents
+curl -X POST http://localhost:8911/api/v1/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-User-ID: admin" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {
+    "name": "servicenow__search_incidents",
+    "arguments": {"correlation_id": "SUSE-AI-DEMO"}
+  }}'
+
+# Get Databricks error metrics
+curl -X POST http://localhost:8911/api/v1/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-User-ID: admin" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {
+    "name": "databricks__get_error_metrics",
+    "arguments": {"time_range": "last_6_hours"}
+  }}'
+```
+
+## Alternative: Docker Compose
+
+For running without Kubernetes:
+
+```bash
+# Build images
+docker build -t suse-ai-up:local ../../
+docker build -t servicenow-mcp:local -f servers/Dockerfile.servicenow servers/
+docker build -t databricks-mcp:local -f servers/Dockerfile.databricks servers/
+
+# Start services
+docker-compose up -d
+
+# Register adapters (use --local flag for localhost endpoints)
+./scripts/register-adapters.sh --local
+```
+
+## Viewing Logs
+
+```bash
+# Proxy logs (shows tool calls with timing)
+kubectl logs -n servicenow-databricks-demo deployment/suse-ai-proxy -f
+
+# Filter for tool calls
+kubectl logs -n servicenow-databricks-demo deployment/suse-ai-proxy | grep TOOL_CALL
+
+# MCP server logs
+kubectl logs -n servicenow-databricks-demo deployment/servicenow-mcp
+kubectl logs -n servicenow-databricks-demo deployment/databricks-mcp
+```
+
+## Troubleshooting
+
+### Port forward died
+```bash
+lsof -ti:8911 | xargs kill -9 2>/dev/null
+kubectl port-forward -n servicenow-databricks-demo svc/suse-ai-proxy 8911:8911 &
+```
+
+### Adapters not registered
+```bash
+./scripts/register-adapters.sh
+```
+
+### Claude Code shows "Capabilities: none"
+Ensure you added the X-User-ID header:
+```bash
+claude mcp remove suse-ai-proxy -s local
+claude mcp add suse-ai-proxy http://localhost:8911/api/v1/mcp \
+  --transport http \
+  -H "X-User-ID: admin"
+```
+
+### Check pod status
+```bash
+kubectl get pods -n servicenow-databricks-demo
+kubectl describe pod -n servicenow-databricks-demo <pod-name>
+```
+
+## Cleanup
+
+```bash
+kubectl delete namespace servicenow-databricks-demo
+```

--- a/examples/servicenow-databricks-demo/claude-code-mcp-config.json
+++ b/examples/servicenow-databricks-demo/claude-code-mcp-config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "suse-ai-proxy": {
+      "type": "http",
+      "url": "http://localhost:8911/api/v1/mcp",
+      "headers": {
+        "X-User-ID": "admin",
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}

--- a/examples/servicenow-databricks-demo/docker-compose.yaml
+++ b/examples/servicenow-databricks-demo/docker-compose.yaml
@@ -1,0 +1,102 @@
+# Docker Compose for ServiceNow + Databricks Demo
+#
+# Alternative to Kubernetes deployment - runs everything in Docker containers.
+#
+# This sets up:
+# 1. SUSE AI Universal Proxy
+# 2. ServiceNow MCP Server (mock or real mode)
+# 3. Databricks MCP Server (mock or real mode)
+#
+# Usage:
+#   # Build local images first
+#   docker build -t suse-ai-up:local ../../
+#   docker build -t servicenow-mcp:local -f servers/Dockerfile.servicenow servers/
+#   docker build -t databricks-mcp:local -f servers/Dockerfile.databricks servers/
+#
+#   # Start services (mock mode - uses demo data)
+#   docker-compose up
+#
+#   # Real mode - create .env file with credentials, then:
+#   docker-compose up
+#
+#   # After startup, register adapters:
+#   ./scripts/register-adapters.sh --local
+#
+# Access:
+#   - Unified MCP endpoint: http://localhost:8911/api/v1/mcp
+#   - Proxy health: http://localhost:8911/health
+
+version: '3.8'
+
+services:
+  # SUSE AI Universal Proxy
+  proxy:
+    image: suse-ai-up:local
+    container_name: suse-ai-proxy
+    ports:
+      - "8911:8911"
+    environment:
+      - AUTH_MODE=dev
+      - LOG_LEVEL=info
+      - DATA_DIR=/tmp/data
+      - HOME=/tmp
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8911/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - demo-network
+
+  # ServiceNow MCP Server
+  servicenow-mcp:
+    image: servicenow-mcp:local
+    container_name: servicenow-mcp
+    ports:
+      - "8000:8000"
+    environment:
+      - SERVICENOW_MOCK_MODE=${SERVICENOW_MOCK_MODE:-true}
+      - SERVICENOW_INSTANCE_URL=${SERVICENOW_INSTANCE_URL:-}
+      - SERVICENOW_AUTH_METHOD=${SERVICENOW_AUTH_METHOD:-basic}
+      # OAuth 2.0 (recommended for production)
+      - SERVICENOW_CLIENT_ID=${SERVICENOW_CLIENT_ID:-}
+      - SERVICENOW_CLIENT_SECRET=${SERVICENOW_CLIENT_SECRET:-}
+      # Personal Access Token
+      - SERVICENOW_PAT=${SERVICENOW_PAT:-}
+      # Basic Auth (legacy)
+      - SERVICENOW_USERNAME=${SERVICENOW_USERNAME:-}
+      - SERVICENOW_PASSWORD=${SERVICENOW_PASSWORD:-}
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - demo-network
+
+  # Databricks MCP Server
+  databricks-mcp:
+    image: databricks-mcp:local
+    container_name: databricks-mcp
+    ports:
+      - "8001:8001"
+    environment:
+      - DATABRICKS_MOCK_MODE=${DATABRICKS_MOCK_MODE:-true}
+      - DATABRICKS_HOST=${DATABRICKS_HOST:-}
+      - DATABRICKS_TOKEN=${DATABRICKS_TOKEN:-}
+      - DATABRICKS_WAREHOUSE_ID=${DATABRICKS_WAREHOUSE_ID:-}
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8001
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - demo-network
+
+networks:
+  demo-network:
+    driver: bridge

--- a/examples/servicenow-databricks-demo/k8s/configmap.yaml
+++ b/examples/servicenow-databricks-demo/k8s/configmap.yaml
@@ -1,0 +1,21 @@
+# ConfigMap for demo configuration
+# Controls mock vs real mode for the MCP servers
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-config
+  namespace: servicenow-databricks-demo
+  labels:
+    app.kubernetes.io/name: servicenow-databricks-demo
+data:
+  # Set to "false" to use real ServiceNow/Databricks APIs
+  SERVICENOW_MOCK_MODE: "true"
+  DATABRICKS_MOCK_MODE: "true"
+
+  # ServiceNow auth method: "oauth" (recommended), "pat", or "basic"
+  SERVICENOW_AUTH_METHOD: "oauth"
+
+  # MCP server configuration
+  MCP_HOST: "0.0.0.0"
+  SERVICENOW_MCP_PORT: "8000"
+  DATABRICKS_MCP_PORT: "8001"

--- a/examples/servicenow-databricks-demo/k8s/databricks-deployment.yaml
+++ b/examples/servicenow-databricks-demo/k8s/databricks-deployment.yaml
@@ -1,0 +1,92 @@
+# Databricks MCP Server Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: databricks-mcp
+  namespace: servicenow-databricks-demo
+  labels:
+    app: databricks-mcp
+    app.kubernetes.io/name: databricks-mcp
+    app.kubernetes.io/part-of: servicenow-databricks-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: databricks-mcp
+  template:
+    metadata:
+      labels:
+        app: databricks-mcp
+    spec:
+      containers:
+        - name: databricks-mcp
+          image: databricks-mcp:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8001
+              name: http
+          env:
+            - name: MCP_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: MCP_HOST
+            - name: MCP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: DATABRICKS_MCP_PORT
+            - name: DATABRICKS_MOCK_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: DATABRICKS_MOCK_MODE
+            # Optional: Real credentials (only used when MOCK_MODE=false)
+            - name: DATABRICKS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: databricks-credentials
+                  key: DATABRICKS_HOST
+                  optional: true
+            - name: DATABRICKS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: databricks-credentials
+                  key: DATABRICKS_TOKEN
+                  optional: true
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: databricks-mcp
+  namespace: servicenow-databricks-demo
+  labels:
+    app: databricks-mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8001
+      targetPort: 8001
+      protocol: TCP
+      name: http
+  selector:
+    app: databricks-mcp

--- a/examples/servicenow-databricks-demo/k8s/kustomization.yaml
+++ b/examples/servicenow-databricks-demo/k8s/kustomization.yaml
@@ -1,0 +1,26 @@
+# Kustomization for ServiceNow + Databricks Demo
+# Usage: kubectl apply -k k8s/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: servicenow-databricks-demo
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - proxy-deployment.yaml
+  - servicenow-deployment.yaml
+  - databricks-deployment.yaml
+
+# Uncomment to include secrets (copy secrets.yaml.template to secrets.yaml first)
+# - secrets.yaml
+
+# Note: Don't use commonLabels as it modifies selectors which are immutable
+labels:
+  - pairs:
+      demo: servicenow-databricks
+      managed-by: suse-ai-up
+    includeSelectors: false
+
+# For RKE2 or production deployments, you can add overlays
+# See k8s/overlays/ for examples

--- a/examples/servicenow-databricks-demo/k8s/namespace.yaml
+++ b/examples/servicenow-databricks-demo/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+# Namespace for the ServiceNow + Databricks demo
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: servicenow-databricks-demo
+  labels:
+    app.kubernetes.io/name: servicenow-databricks-demo
+    app.kubernetes.io/part-of: suse-ai-up

--- a/examples/servicenow-databricks-demo/k8s/overlays/mock/kustomization.yaml
+++ b/examples/servicenow-databricks-demo/k8s/overlays/mock/kustomization.yaml
@@ -1,0 +1,18 @@
+# Mock mode overlay - uses demo data, no real API connections
+# Usage: kubectl apply -k k8s/overlays/mock/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../
+
+patches:
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: demo-config
+        namespace: servicenow-databricks-demo
+      data:
+        SERVICENOW_MOCK_MODE: "true"
+        DATABRICKS_MOCK_MODE: "true"

--- a/examples/servicenow-databricks-demo/k8s/overlays/production/configmap-patch.yaml
+++ b/examples/servicenow-databricks-demo/k8s/overlays/production/configmap-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-config
+  namespace: servicenow-databricks-demo
+data:
+  # Production mode - use real APIs
+  SERVICENOW_MOCK_MODE: "false"
+  DATABRICKS_MOCK_MODE: "false"
+
+  # ServiceNow auth method
+  SERVICENOW_AUTH_METHOD: "basic"
+
+  # MCP server configuration
+  MCP_HOST: "0.0.0.0"
+  SERVICENOW_MCP_PORT: "8000"
+  DATABRICKS_MCP_PORT: "8001"

--- a/examples/servicenow-databricks-demo/k8s/overlays/production/databricks-deployment-patch.yaml
+++ b/examples/servicenow-databricks-demo/k8s/overlays/production/databricks-deployment-patch.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: databricks-mcp
+  namespace: servicenow-databricks-demo
+spec:
+  template:
+    spec:
+      containers:
+        - name: databricks-mcp
+          env:
+            - name: MCP_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: MCP_HOST
+            - name: MCP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: DATABRICKS_MCP_PORT
+            - name: DATABRICKS_MOCK_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: DATABRICKS_MOCK_MODE
+            - name: DATABRICKS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: databricks-credentials
+                  key: DATABRICKS_HOST
+            - name: DATABRICKS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: databricks-credentials
+                  key: DATABRICKS_TOKEN
+            - name: DATABRICKS_WAREHOUSE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: databricks-credentials
+                  key: DATABRICKS_WAREHOUSE_ID
+            - name: DATABRICKS_CATALOG
+              valueFrom:
+                secretKeyRef:
+                  name: databricks-credentials
+                  key: DATABRICKS_CATALOG
+            - name: DATABRICKS_SCHEMA
+              valueFrom:
+                secretKeyRef:
+                  name: databricks-credentials
+                  key: DATABRICKS_SCHEMA

--- a/examples/servicenow-databricks-demo/k8s/overlays/production/kustomization.yaml
+++ b/examples/servicenow-databricks-demo/k8s/overlays/production/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: servicenow-databricks-demo
+
+resources:
+  - ../../namespace.yaml
+  - ../../configmap.yaml
+  - ../../proxy-deployment.yaml
+  - ../../servicenow-deployment.yaml
+  - ../../databricks-deployment.yaml
+
+patches:
+  - path: configmap-patch.yaml
+  - path: databricks-deployment-patch.yaml
+
+commonLabels:
+  demo: servicenow-databricks
+  managed-by: suse-ai-up

--- a/examples/servicenow-databricks-demo/k8s/overlays/real/generate-secrets.sh
+++ b/examples/servicenow-databricks-demo/k8s/overlays/real/generate-secrets.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Generate secrets.yaml from environment variables
+#
+# Supports multiple ServiceNow authentication methods:
+# - OAuth 2.0 (recommended)
+# - Personal Access Token (PAT)
+# - Basic Auth (legacy)
+#
+# Usage:
+#   # OAuth 2.0 (recommended)
+#   export SERVICENOW_INSTANCE_URL="https://devXXXXX.service-now.com"
+#   export SERVICENOW_AUTH_METHOD="oauth"
+#   export SERVICENOW_CLIENT_ID="your_client_id"
+#   export SERVICENOW_CLIENT_SECRET="your_client_secret"
+#
+#   # Personal Access Token
+#   export SERVICENOW_INSTANCE_URL="https://devXXXXX.service-now.com"
+#   export SERVICENOW_AUTH_METHOD="pat"
+#   export SERVICENOW_PAT="your_personal_access_token"
+#
+#   # Basic Auth (legacy)
+#   export SERVICENOW_INSTANCE_URL="https://devXXXXX.service-now.com"
+#   export SERVICENOW_AUTH_METHOD="basic"
+#   export SERVICENOW_USERNAME="admin"
+#   export SERVICENOW_PASSWORD="your_password"
+#
+#   # Databricks
+#   export DATABRICKS_HOST="https://dbc-xxxxx.cloud.databricks.com"
+#   export DATABRICKS_TOKEN="dapi-xxxxxxxx"
+#
+#   ./generate-secrets.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default auth method
+SERVICENOW_AUTH_METHOD="${SERVICENOW_AUTH_METHOD:-oauth}"
+
+# Check required variables
+if [ -z "$SERVICENOW_INSTANCE_URL" ]; then
+    echo "Error: SERVICENOW_INSTANCE_URL not set"
+    exit 1
+fi
+
+# Validate auth method specific credentials
+case "$SERVICENOW_AUTH_METHOD" in
+    oauth)
+        if [ -z "$SERVICENOW_CLIENT_ID" ] || [ -z "$SERVICENOW_CLIENT_SECRET" ]; then
+            echo "Error: OAuth requires SERVICENOW_CLIENT_ID and SERVICENOW_CLIENT_SECRET"
+            exit 1
+        fi
+        ;;
+    pat)
+        if [ -z "$SERVICENOW_PAT" ]; then
+            echo "Error: PAT auth requires SERVICENOW_PAT"
+            exit 1
+        fi
+        ;;
+    basic)
+        if [ -z "$SERVICENOW_USERNAME" ] || [ -z "$SERVICENOW_PASSWORD" ]; then
+            echo "Error: Basic auth requires SERVICENOW_USERNAME and SERVICENOW_PASSWORD"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Error: Invalid auth method '$SERVICENOW_AUTH_METHOD'. Use 'oauth', 'pat', or 'basic'"
+        exit 1
+        ;;
+esac
+
+if [ -z "$DATABRICKS_HOST" ] || [ -z "$DATABRICKS_TOKEN" ]; then
+    echo "Error: Databricks credentials not set"
+    echo "Required: DATABRICKS_HOST, DATABRICKS_TOKEN"
+    exit 1
+fi
+
+# Helper function to base64 encode, handling empty values
+b64_encode() {
+    if [ -n "$1" ]; then
+        echo -n "$1" | base64
+    else
+        echo ""
+    fi
+}
+
+# Generate secrets.yaml
+cat > "$SCRIPT_DIR/secrets.yaml" << EOF
+# Auto-generated secrets file
+# Generated on: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Auth method: ${SERVICENOW_AUTH_METHOD}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: servicenow-credentials
+  namespace: servicenow-databricks-demo
+type: Opaque
+data:
+  SERVICENOW_INSTANCE_URL: $(b64_encode "$SERVICENOW_INSTANCE_URL")
+  SERVICENOW_AUTH_METHOD: $(b64_encode "$SERVICENOW_AUTH_METHOD")
+  # OAuth 2.0
+  SERVICENOW_CLIENT_ID: $(b64_encode "$SERVICENOW_CLIENT_ID")
+  SERVICENOW_CLIENT_SECRET: $(b64_encode "$SERVICENOW_CLIENT_SECRET")
+  # PAT
+  SERVICENOW_PAT: $(b64_encode "$SERVICENOW_PAT")
+  # Basic Auth
+  SERVICENOW_USERNAME: $(b64_encode "$SERVICENOW_USERNAME")
+  SERVICENOW_PASSWORD: $(b64_encode "$SERVICENOW_PASSWORD")
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: databricks-credentials
+  namespace: servicenow-databricks-demo
+type: Opaque
+data:
+  DATABRICKS_HOST: $(b64_encode "$DATABRICKS_HOST")
+  DATABRICKS_TOKEN: $(b64_encode "$DATABRICKS_TOKEN")
+EOF
+
+echo "Generated $SCRIPT_DIR/secrets.yaml"
+echo "ServiceNow auth method: $SERVICENOW_AUTH_METHOD"
+echo "Deploy with: kubectl apply -k $SCRIPT_DIR"

--- a/examples/servicenow-databricks-demo/k8s/overlays/real/kustomization.yaml
+++ b/examples/servicenow-databricks-demo/k8s/overlays/real/kustomization.yaml
@@ -1,0 +1,22 @@
+# Real mode overlay - connects to actual ServiceNow and Databricks APIs
+# Usage:
+#   1. Copy secrets.yaml.template to this directory as secrets.yaml
+#   2. Fill in your credentials (base64 encoded)
+#   3. kubectl apply -k k8s/overlays/real/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../
+  - secrets.yaml
+
+patches:
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: demo-config
+        namespace: servicenow-databricks-demo
+      data:
+        SERVICENOW_MOCK_MODE: "false"
+        DATABRICKS_MOCK_MODE: "false"

--- a/examples/servicenow-databricks-demo/k8s/proxy-deployment.yaml
+++ b/examples/servicenow-databricks-demo/k8s/proxy-deployment.yaml
@@ -1,0 +1,82 @@
+# SUSE AI Universal Proxy Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: suse-ai-proxy
+  namespace: servicenow-databricks-demo
+  labels:
+    app: suse-ai-proxy
+    app.kubernetes.io/name: suse-ai-proxy
+    app.kubernetes.io/part-of: servicenow-databricks-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: suse-ai-proxy
+  template:
+    metadata:
+      labels:
+        app: suse-ai-proxy
+    spec:
+      containers:
+        - name: suse-ai-proxy
+          image: suse-ai-up:local
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8911
+              name: http
+          env:
+            - name: AUTH_MODE
+              value: "dev"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: DATA_DIR
+              value: "/tmp/data"
+            - name: HOME
+              value: "/tmp"
+          volumeMounts:
+            - name: data-volume
+              mountPath: /tmp/data
+            - name: cache-volume
+              mountPath: /tmp/.cache
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8911
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8911
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data-volume
+          emptyDir: {}
+        - name: cache-volume
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: suse-ai-proxy
+  namespace: servicenow-databricks-demo
+  labels:
+    app: suse-ai-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8911
+      targetPort: 8911
+      protocol: TCP
+      name: http
+  selector:
+    app: suse-ai-proxy

--- a/examples/servicenow-databricks-demo/k8s/secrets.yaml.template
+++ b/examples/servicenow-databricks-demo/k8s/secrets.yaml.template
@@ -1,0 +1,55 @@
+# Secrets for ServiceNow and Databricks credentials
+# Copy this file to secrets.yaml and fill in your values
+# Then apply with: kubectl apply -f secrets.yaml
+#
+# NOTE: Values must be base64 encoded
+# Use: echo -n "your-value" | base64
+apiVersion: v1
+kind: Secret
+metadata:
+  name: servicenow-credentials
+  namespace: servicenow-databricks-demo
+  labels:
+    app.kubernetes.io/name: servicenow-databricks-demo
+type: Opaque
+data:
+  # ServiceNow Developer Instance URL
+  # echo -n "https://devXXXXX.service-now.com" | base64
+  SERVICENOW_INSTANCE_URL: ""
+
+  # Authentication Method: "oauth", "pat", or "basic"
+  # echo -n "oauth" | base64
+  SERVICENOW_AUTH_METHOD: ""
+
+  # OAuth 2.0 credentials (recommended)
+  # Create OAuth app in ServiceNow: System OAuth > Application Registry
+  # echo -n "your_client_id" | base64
+  SERVICENOW_CLIENT_ID: ""
+  # echo -n "your_client_secret" | base64
+  SERVICENOW_CLIENT_SECRET: ""
+
+  # Personal Access Token (San Diego release and later)
+  # Create in ServiceNow: User Profile > Personal Access Tokens
+  # echo -n "your_pat" | base64
+  SERVICENOW_PAT: ""
+
+  # Basic Auth credentials (legacy - not recommended)
+  # echo -n "admin" | base64
+  SERVICENOW_USERNAME: ""
+  # echo -n "your_password" | base64
+  SERVICENOW_PASSWORD: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: databricks-credentials
+  namespace: servicenow-databricks-demo
+  labels:
+    app.kubernetes.io/name: servicenow-databricks-demo
+type: Opaque
+data:
+  # Databricks workspace credentials
+  # echo -n "https://dbc-xxxxx.cloud.databricks.com" | base64
+  DATABRICKS_HOST: ""
+  # echo -n "dapi-xxxxxxxx" | base64
+  DATABRICKS_TOKEN: ""

--- a/examples/servicenow-databricks-demo/k8s/servicenow-deployment.yaml
+++ b/examples/servicenow-databricks-demo/k8s/servicenow-deployment.yaml
@@ -1,0 +1,124 @@
+# ServiceNow MCP Server Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: servicenow-mcp
+  namespace: servicenow-databricks-demo
+  labels:
+    app: servicenow-mcp
+    app.kubernetes.io/name: servicenow-mcp
+    app.kubernetes.io/part-of: servicenow-databricks-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: servicenow-mcp
+  template:
+    metadata:
+      labels:
+        app: servicenow-mcp
+    spec:
+      containers:
+        - name: servicenow-mcp
+          image: servicenow-mcp:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: MCP_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: MCP_HOST
+            - name: MCP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: SERVICENOW_MCP_PORT
+            - name: SERVICENOW_MOCK_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: SERVICENOW_MOCK_MODE
+            - name: SERVICENOW_AUTH_METHOD
+              valueFrom:
+                configMapKeyRef:
+                  name: demo-config
+                  key: SERVICENOW_AUTH_METHOD
+            # ServiceNow instance URL (required for real mode)
+            - name: SERVICENOW_INSTANCE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: servicenow-credentials
+                  key: SERVICENOW_INSTANCE_URL
+                  optional: true
+            # OAuth 2.0 credentials (recommended)
+            - name: SERVICENOW_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: servicenow-credentials
+                  key: SERVICENOW_CLIENT_ID
+                  optional: true
+            - name: SERVICENOW_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: servicenow-credentials
+                  key: SERVICENOW_CLIENT_SECRET
+                  optional: true
+            # Personal Access Token
+            - name: SERVICENOW_PAT
+              valueFrom:
+                secretKeyRef:
+                  name: servicenow-credentials
+                  key: SERVICENOW_PAT
+                  optional: true
+            # Basic Auth (legacy)
+            - name: SERVICENOW_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: servicenow-credentials
+                  key: SERVICENOW_USERNAME
+                  optional: true
+            - name: SERVICENOW_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: servicenow-credentials
+                  key: SERVICENOW_PASSWORD
+                  optional: true
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: servicenow-mcp
+  namespace: servicenow-databricks-demo
+  labels:
+    app: servicenow-mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    app: servicenow-mcp

--- a/examples/servicenow-databricks-demo/scripts/deploy-production.sh
+++ b/examples/servicenow-databricks-demo/scripts/deploy-production.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# Deploy MCP servers in production mode (real ServiceNow + Databricks)
+#
+# Prerequisites:
+#   - .env file configured with real credentials
+#   - Demo data loaded in ServiceNow and Databricks
+#   - Kubernetes cluster running (Rancher Desktop or RKE2)
+#
+# Usage:
+#   ./scripts/deploy-production.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env if it exists
+if [ -f "$PROJECT_DIR/.env" ]; then
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}"
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║         Deploying MCP Servers in Production Mode                 ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# Check prerequisites
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+
+if [ -z "$SERVICENOW_INSTANCE_URL" ]; then
+    echo -e "${RED}Error: SERVICENOW_INSTANCE_URL not set. Configure .env first.${NC}"
+    exit 1
+fi
+
+if [ -z "$DATABRICKS_HOST" ]; then
+    echo -e "${RED}Error: DATABRICKS_HOST not set. Configure .env first.${NC}"
+    exit 1
+fi
+
+if ! kubectl cluster-info > /dev/null 2>&1; then
+    echo -e "${RED}Error: Cannot connect to Kubernetes cluster${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Prerequisites OK${NC}"
+echo ""
+
+# Create namespace if it doesn't exist
+echo -e "${YELLOW}Ensuring namespace exists...${NC}"
+kubectl create namespace servicenow-databricks-demo --dry-run=client -o yaml | kubectl apply -f -
+echo ""
+
+# Create/update secrets
+echo -e "${YELLOW}Creating Kubernetes secrets...${NC}"
+
+# Delete existing secrets (to update them)
+kubectl delete secret servicenow-credentials -n servicenow-databricks-demo 2>/dev/null || true
+kubectl delete secret databricks-credentials -n servicenow-databricks-demo 2>/dev/null || true
+
+# Create ServiceNow secret
+kubectl create secret generic servicenow-credentials \
+    --namespace servicenow-databricks-demo \
+    --from-literal=SERVICENOW_INSTANCE_URL="${SERVICENOW_INSTANCE_URL}" \
+    --from-literal=SERVICENOW_USERNAME="${SERVICENOW_USERNAME}" \
+    --from-literal=SERVICENOW_PASSWORD="${SERVICENOW_PASSWORD}" \
+    --from-literal=SERVICENOW_AUTH_METHOD="${SERVICENOW_AUTH_METHOD:-basic}" \
+    --from-literal=SERVICENOW_PAT="${SERVICENOW_PAT:-}" \
+    --from-literal=SERVICENOW_CLIENT_ID="${SERVICENOW_CLIENT_ID:-}" \
+    --from-literal=SERVICENOW_CLIENT_SECRET="${SERVICENOW_CLIENT_SECRET:-}"
+
+echo -e "${GREEN}  ServiceNow credentials created${NC}"
+
+# Create Databricks secret
+kubectl create secret generic databricks-credentials \
+    --namespace servicenow-databricks-demo \
+    --from-literal=DATABRICKS_HOST="${DATABRICKS_HOST}" \
+    --from-literal=DATABRICKS_TOKEN="${DATABRICKS_TOKEN}" \
+    --from-literal=DATABRICKS_WAREHOUSE_ID="${DATABRICKS_WAREHOUSE_ID}" \
+    --from-literal=DATABRICKS_CATALOG="${DATABRICKS_CATALOG:-workspace}" \
+    --from-literal=DATABRICKS_SCHEMA="${DATABRICKS_SCHEMA:-analytics}"
+
+echo -e "${GREEN}  Databricks credentials created${NC}"
+echo ""
+
+# Delete existing deployments (selectors are immutable)
+echo -e "${YELLOW}Removing existing deployments...${NC}"
+kubectl delete deployment servicenow-mcp databricks-mcp suse-ai-proxy -n servicenow-databricks-demo 2>/dev/null || true
+
+# Apply base configuration
+echo -e "${YELLOW}Applying base configuration...${NC}"
+kubectl apply -k "$PROJECT_DIR/k8s/"
+
+# Patch configmap for production mode
+echo -e "${YELLOW}Patching configmap for production mode...${NC}"
+kubectl patch configmap demo-config -n servicenow-databricks-demo --type merge -p '{
+  "data": {
+    "SERVICENOW_MOCK_MODE": "false",
+    "DATABRICKS_MOCK_MODE": "false",
+    "SERVICENOW_AUTH_METHOD": "basic"
+  }
+}'
+
+# Patch databricks deployment to add warehouse/catalog/schema env vars
+echo -e "${YELLOW}Patching Databricks deployment...${NC}"
+kubectl patch deployment databricks-mcp -n servicenow-databricks-demo --type json -p '[
+  {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "DATABRICKS_WAREHOUSE_ID", "valueFrom": {"secretKeyRef": {"name": "databricks-credentials", "key": "DATABRICKS_WAREHOUSE_ID"}}}},
+  {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "DATABRICKS_CATALOG", "valueFrom": {"secretKeyRef": {"name": "databricks-credentials", "key": "DATABRICKS_CATALOG"}}}},
+  {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "DATABRICKS_SCHEMA", "valueFrom": {"secretKeyRef": {"name": "databricks-credentials", "key": "DATABRICKS_SCHEMA"}}}}
+]'
+echo ""
+
+# Wait for deployments to be ready
+echo -e "${YELLOW}Waiting for deployments to be ready...${NC}"
+kubectl rollout status deployment/servicenow-mcp -n servicenow-databricks-demo --timeout=120s
+kubectl rollout status deployment/databricks-mcp -n servicenow-databricks-demo --timeout=120s
+kubectl rollout status deployment/suse-ai-proxy -n servicenow-databricks-demo --timeout=120s
+echo ""
+
+# Show pod status
+echo -e "${YELLOW}Pod status:${NC}"
+kubectl get pods -n servicenow-databricks-demo
+echo ""
+
+echo -e "${GREEN}╔══════════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║         Production deployment complete!                          ║${NC}"
+echo -e "${GREEN}╚══════════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo "Next steps:"
+echo ""
+echo "  1. Port forward the proxy:"
+echo "     kubectl port-forward -n servicenow-databricks-demo svc/suse-ai-proxy 8911:8911"
+echo ""
+echo "  2. Register the adapters:"
+echo "     ./scripts/register-adapters.sh"
+echo ""
+echo "  3. Configure Claude Code (see claude-code-mcp-config.json)"
+echo ""

--- a/examples/servicenow-databricks-demo/scripts/load-databricks-data.sh
+++ b/examples/servicenow-databricks-demo/scripts/load-databricks-data.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+#
+# Load demo analytics data into Databricks
+#
+# This creates tables with error metrics and system events
+# that correlate with ServiceNow incidents for the demo.
+#
+# Prerequisites:
+#   - Databricks workspace with SQL Warehouse
+#   - Personal Access Token
+#   - Unity Catalog enabled (or adjust catalog/schema names)
+#
+# Usage:
+#   export DATABRICKS_HOST="https://dbc-xxxxx.cloud.databricks.com"
+#   export DATABRICKS_TOKEN="dapi-xxxxxxxx"
+#   export DATABRICKS_WAREHOUSE_ID="your-warehouse-id"  # Optional
+#   ./load-databricks-data.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env if it exists
+if [ -f "$PROJECT_DIR/.env" ]; then
+    echo "Loading configuration from .env..."
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Configuration
+DATABRICKS_HOST="${DATABRICKS_HOST:-}"
+DATABRICKS_TOKEN="${DATABRICKS_TOKEN:-}"
+WAREHOUSE_ID="${DATABRICKS_WAREHOUSE_ID:-}"
+CATALOG="${DATABRICKS_CATALOG:-main}"
+SCHEMA="${DATABRICKS_SCHEMA:-analytics}"
+
+echo -e "${BLUE}"
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║         Loading Demo Data into Databricks                        ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# Validate configuration
+if [ -z "$DATABRICKS_HOST" ]; then
+    echo -e "${RED}Error: DATABRICKS_HOST is required${NC}"
+    echo ""
+    echo "Usage:"
+    echo "  export DATABRICKS_HOST=\"https://dbc-xxxxx.cloud.databricks.com\""
+    echo "  export DATABRICKS_TOKEN=\"dapi-xxxxxxxx\""
+    echo "  ./load-databricks-data.sh"
+    exit 1
+fi
+
+if [ -z "$DATABRICKS_TOKEN" ]; then
+    echo -e "${RED}Error: DATABRICKS_TOKEN is required${NC}"
+    exit 1
+fi
+
+# Remove trailing slash
+DATABRICKS_HOST="${DATABRICKS_HOST%/}"
+
+echo -e "${YELLOW}Host: ${DATABRICKS_HOST}${NC}"
+echo -e "${YELLOW}Catalog: ${CATALOG}${NC}"
+echo -e "${YELLOW}Schema: ${SCHEMA}${NC}"
+echo ""
+
+# Test connection
+echo -e "${YELLOW}Testing connection...${NC}"
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+    "${DATABRICKS_HOST}/api/2.0/clusters/list")
+
+if [ "$RESPONSE" != "200" ]; then
+    echo -e "${RED}Failed to connect to Databricks (HTTP ${RESPONSE})${NC}"
+    echo "Check your credentials and host URL"
+    exit 1
+fi
+echo -e "${GREEN}Connection successful${NC}"
+echo ""
+
+# Find a SQL warehouse if not specified
+if [ -z "$WAREHOUSE_ID" ]; then
+    echo -e "${YELLOW}Finding SQL warehouse...${NC}"
+    WAREHOUSES=$(curl -s \
+        -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+        "${DATABRICKS_HOST}/api/2.0/sql/warehouses")
+
+    WAREHOUSE_ID=$(echo "$WAREHOUSES" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+warehouses = data.get('warehouses', [])
+# Prefer running warehouse, otherwise first available
+for w in warehouses:
+    if w.get('state') == 'RUNNING':
+        print(w['id'])
+        sys.exit(0)
+if warehouses:
+    print(warehouses[0]['id'])
+" 2>/dev/null || echo "")
+
+    if [ -z "$WAREHOUSE_ID" ]; then
+        echo -e "${RED}No SQL warehouse found. Please create one or specify DATABRICKS_WAREHOUSE_ID${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}Found warehouse: ${WAREHOUSE_ID}${NC}"
+fi
+
+echo ""
+
+# Function to execute SQL
+execute_sql() {
+    local statement="$1"
+    local description="$2"
+
+    echo -e "${YELLOW}${description}...${NC}"
+
+    RESULT=$(curl -s -X POST \
+        -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "${DATABRICKS_HOST}/api/2.0/sql/statements" \
+        -d "{
+            \"warehouse_id\": \"${WAREHOUSE_ID}\",
+            \"statement\": $(echo "$statement" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'),
+            \"wait_timeout\": \"30s\"
+        }")
+
+    STATUS=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',{}).get('state','UNKNOWN'))" 2>/dev/null || echo "ERROR")
+
+    if [ "$STATUS" = "SUCCEEDED" ]; then
+        echo -e "${GREEN}  Success${NC}"
+    elif [ "$STATUS" = "RUNNING" ] || [ "$STATUS" = "PENDING" ]; then
+        echo -e "${YELLOW}  Running (async)${NC}"
+    else
+        echo -e "${RED}  Failed: ${STATUS}${NC}"
+        ERROR=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',{}).get('error',{}).get('message','Unknown error'))" 2>/dev/null || echo "$RESULT")
+        echo -e "${RED}  Error: ${ERROR}${NC}"
+    fi
+}
+
+echo -e "${BLUE}Creating schema and tables...${NC}"
+echo ""
+
+# Create schema
+execute_sql "CREATE SCHEMA IF NOT EXISTS ${CATALOG}.${SCHEMA}" \
+    "Creating schema ${CATALOG}.${SCHEMA}"
+
+# Create error_metrics_hourly table
+execute_sql "
+CREATE TABLE IF NOT EXISTS ${CATALOG}.${SCHEMA}.error_metrics_hourly (
+    timestamp TIMESTAMP,
+    hour STRING,
+    error_count INT,
+    error_rate DOUBLE,
+    top_error_type STRING,
+    source_system STRING
+)
+" "Creating error_metrics_hourly table"
+
+# Create system_events table
+execute_sql "
+CREATE TABLE IF NOT EXISTS ${CATALOG}.${SCHEMA}.system_events (
+    event_id STRING,
+    timestamp TIMESTAMP,
+    event_type STRING,
+    source STRING,
+    details STRING,
+    severity STRING,
+    correlation_id STRING
+)
+" "Creating system_events table"
+
+# Create system_health table
+execute_sql "
+CREATE TABLE IF NOT EXISTS ${CATALOG}.${SCHEMA}.system_health (
+    timestamp TIMESTAMP,
+    metric_name STRING,
+    current_value DOUBLE,
+    threshold DOUBLE,
+    status STRING,
+    component STRING
+)
+" "Creating system_health table"
+
+echo ""
+echo -e "${BLUE}Loading demo data...${NC}"
+echo ""
+
+# Get current timestamp for data
+CURRENT_TS=$(date -u +"%Y-%m-%dT%H:%M:%S")
+HOUR_AGO=$(date -u -v-1H +"%Y-%m-%dT%H:%M:%S" 2>/dev/null || date -u -d "1 hour ago" +"%Y-%m-%dT%H:%M:%S")
+
+# Load error metrics (showing spike pattern)
+execute_sql "
+INSERT INTO ${CATALOG}.${SCHEMA}.error_metrics_hourly VALUES
+    (current_timestamp() - INTERVAL 6 HOURS, DATE_FORMAT(current_timestamp() - INTERVAL 6 HOURS, 'yyyy-MM-dd HH:00'), 45, 0.05, 'ConnectionTimeout', 'database'),
+    (current_timestamp() - INTERVAL 5 HOURS, DATE_FORMAT(current_timestamp() - INTERVAL 5 HOURS, 'yyyy-MM-dd HH:00'), 120, 0.12, 'ConnectionTimeout', 'database'),
+    (current_timestamp() - INTERVAL 4 HOURS, DATE_FORMAT(current_timestamp() - INTERVAL 4 HOURS, 'yyyy-MM-dd HH:00'), 230, 0.23, 'ConnectionTimeout', 'database'),
+    (current_timestamp() - INTERVAL 3 HOURS, DATE_FORMAT(current_timestamp() - INTERVAL 3 HOURS, 'yyyy-MM-dd HH:00'), 180, 0.18, 'ConnectionTimeout', 'database'),
+    (current_timestamp() - INTERVAL 2 HOURS, DATE_FORMAT(current_timestamp() - INTERVAL 2 HOURS, 'yyyy-MM-dd HH:00'), 350, 0.35, 'ConnectionTimeout', 'database'),
+    (current_timestamp() - INTERVAL 1 HOURS, DATE_FORMAT(current_timestamp() - INTERVAL 1 HOURS, 'yyyy-MM-dd HH:00'), 280, 0.28, 'ConnectionTimeout', 'database')
+" "Loading error metrics data"
+
+# Load system events (incident correlation timeline)
+execute_sql "
+INSERT INTO ${CATALOG}.${SCHEMA}.system_events VALUES
+    ('EVT-001', current_timestamp() - INTERVAL 125 MINUTES, 'DB_CONNECTION_POOL_EXHAUSTED', 'production-db-cluster-01', 'Max connections reached: 500/500', 'CRITICAL', 'CORR-001'),
+    ('EVT-002', current_timestamp() - INTERVAL 124 MINUTES, 'ETL_JOB_FAILED', 'Daily ETL Pipeline', 'ConnectionTimeout after 30s - job_id: 101', 'HIGH', 'CORR-001'),
+    ('EVT-003', current_timestamp() - INTERVAL 123 MINUTES, 'CLUSTER_SCALE_BLOCKED', 'production-etl-cluster', 'Auto-scale blocked: dependent service unavailable', 'MEDIUM', 'CORR-001'),
+    ('EVT-004', current_timestamp() - INTERVAL 120 MINUTES, 'ALERT_TRIGGERED', 'PagerDuty', 'P1 Alert: Database connectivity issue', 'HIGH', 'CORR-001'),
+    ('EVT-005', current_timestamp() - INTERVAL 115 MINUTES, 'INCIDENT_CREATED', 'ServiceNow', 'INC0010001: Database connection timeout on production cluster', 'HIGH', 'CORR-001'),
+    ('EVT-006', current_timestamp() - INTERVAL 90 MINUTES, 'DATA_QUALITY_ALERT', 'customer_transactions', 'Null values in required fields: 15000 records', 'MEDIUM', 'CORR-002'),
+    ('EVT-007', current_timestamp() - INTERVAL 85 MINUTES, 'INCIDENT_CREATED', 'ServiceNow', 'INC0010003: ETL pipeline data quality alert', 'MEDIUM', 'CORR-002')
+" "Loading system events data"
+
+# Load system health metrics
+execute_sql "
+INSERT INTO ${CATALOG}.${SCHEMA}.system_health VALUES
+    (current_timestamp(), 'db_connection_pool_used', 95, 80, 'CRITICAL', 'database'),
+    (current_timestamp(), 'db_query_latency_p99_ms', 2500, 1000, 'WARNING', 'database'),
+    (current_timestamp(), 'db_active_connections', 450, 500, 'WARNING', 'database'),
+    (current_timestamp(), 'etl_records_processed', 1250000, 0, 'OK', 'etl'),
+    (current_timestamp(), 'etl_failed_records', 15000, 1000, 'CRITICAL', 'etl'),
+    (current_timestamp(), 'cluster_worker_count', 8, 4, 'OK', 'compute'),
+    (current_timestamp(), 'cluster_memory_utilization', 78, 90, 'OK', 'compute'),
+    (current_timestamp(), 'job_queue_depth', 12, 50, 'OK', 'scheduler')
+" "Loading system health data"
+
+echo ""
+echo -e "${GREEN}╔══════════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║         Demo data loaded successfully!                           ║${NC}"
+echo -e "${GREEN}╚══════════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo "Tables created in ${CATALOG}.${SCHEMA}:"
+echo "  - error_metrics_hourly  (error rate trends)"
+echo "  - system_events         (event timeline for correlation)"
+echo "  - system_health         (current health metrics)"
+echo ""
+echo "You can query the data in Databricks SQL:"
+echo ""
+echo "  SELECT * FROM ${CATALOG}.${SCHEMA}.error_metrics_hourly ORDER BY timestamp;"
+echo "  SELECT * FROM ${CATALOG}.${SCHEMA}.system_events ORDER BY timestamp;"
+echo "  SELECT * FROM ${CATALOG}.${SCHEMA}.system_health;"
+echo ""
+echo "Or view in the Databricks UI:"
+echo "  ${DATABRICKS_HOST}/sql/editor"

--- a/examples/servicenow-databricks-demo/scripts/load-servicenow-data.sh
+++ b/examples/servicenow-databricks-demo/scripts/load-servicenow-data.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+#
+# Load demo incident data into ServiceNow
+#
+# This creates incidents that correlate with Databricks error data
+# for the incident correlation demo.
+#
+# Prerequisites:
+#   - ServiceNow developer instance
+#   - Personal Access Token (PAT) or Basic Auth credentials
+#
+# Usage:
+#   export SERVICENOW_INSTANCE_URL="https://devXXXXX.service-now.com"
+#   export SERVICENOW_PAT="your-pat-token"
+#   ./load-servicenow-data.sh
+#
+#   Or with Basic Auth:
+#   export SERVICENOW_USERNAME="admin"
+#   export SERVICENOW_PASSWORD="password"
+#   ./load-servicenow-data.sh
+#
+#   To reset (delete existing demo incidents first):
+#   ./load-servicenow-data.sh --reset
+
+set -e
+
+# Parse arguments
+RESET_MODE=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --reset|-r)
+            RESET_MODE=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env if it exists
+if [ -f "$PROJECT_DIR/.env" ]; then
+    echo "Loading configuration from .env..."
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Configuration
+INSTANCE_URL="${SERVICENOW_INSTANCE_URL:-}"
+PAT="${SERVICENOW_PAT:-}"
+USERNAME="${SERVICENOW_USERNAME:-}"
+PASSWORD="${SERVICENOW_PASSWORD:-}"
+
+echo -e "${BLUE}"
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║         Loading Demo Data into ServiceNow                        ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+if [ "$RESET_MODE" = true ]; then
+    echo -e "${YELLOW}Reset mode: Will delete existing demo incidents first${NC}"
+    echo ""
+fi
+
+# Validate configuration
+if [ -z "$INSTANCE_URL" ]; then
+    echo -e "${RED}Error: SERVICENOW_INSTANCE_URL is required${NC}"
+    echo ""
+    echo "Usage:"
+    echo "  export SERVICENOW_INSTANCE_URL=\"https://devXXXXX.service-now.com\""
+    echo "  export SERVICENOW_PAT=\"your-pat-token\""
+    echo "  ./load-servicenow-data.sh"
+    exit 1
+fi
+
+# Remove trailing slash
+INSTANCE_URL="${INSTANCE_URL%/}"
+
+# Set up authentication based on AUTH_METHOD
+AUTH_METHOD="${SERVICENOW_AUTH_METHOD:-pat}"
+
+if [ "$AUTH_METHOD" = "basic" ] && [ -n "$USERNAME" ] && [ -n "$PASSWORD" ]; then
+    AUTH_HEADER="Authorization: Basic $(echo -n "${USERNAME}:${PASSWORD}" | base64)"
+    echo -e "${YELLOW}Using Basic authentication${NC}"
+elif [ "$AUTH_METHOD" = "pat" ] && [ -n "$PAT" ]; then
+    AUTH_HEADER="Authorization: Bearer ${PAT}"
+    echo -e "${YELLOW}Using PAT authentication${NC}"
+elif [ -n "$USERNAME" ] && [ -n "$PASSWORD" ]; then
+    AUTH_HEADER="Authorization: Basic $(echo -n "${USERNAME}:${PASSWORD}" | base64)"
+    echo -e "${YELLOW}Using Basic authentication${NC}"
+elif [ -n "$PAT" ]; then
+    AUTH_HEADER="Authorization: Bearer ${PAT}"
+    echo -e "${YELLOW}Using PAT authentication${NC}"
+else
+    echo -e "${RED}Error: No authentication credentials provided${NC}"
+    echo "Set either SERVICENOW_PAT or SERVICENOW_USERNAME/SERVICENOW_PASSWORD"
+    exit 1
+fi
+
+echo -e "${YELLOW}Instance: ${INSTANCE_URL}${NC}"
+echo ""
+
+# Test connection
+echo -e "${YELLOW}Testing connection...${NC}"
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "${AUTH_HEADER}" \
+    -H "Content-Type: application/json" \
+    "${INSTANCE_URL}/api/now/table/incident?sysparm_limit=1")
+
+if [ "$RESPONSE" != "200" ]; then
+    echo -e "${RED}Failed to connect to ServiceNow (HTTP ${RESPONSE})${NC}"
+    echo "Check your credentials and instance URL"
+    exit 1
+fi
+echo -e "${GREEN}Connection successful${NC}"
+echo ""
+
+# Demo incident identifier - used for filtering and reset
+DEMO_CORRELATION_ID="SUSE-AI-DEMO"
+
+# Demo incident short descriptions (used for reset matching)
+DEMO_INCIDENTS=(
+    "Database connection timeout on production cluster"
+    "Databricks cluster auto-scaling failure"
+    "ETL pipeline data quality alert"
+    "ML model prediction accuracy degradation"
+)
+
+# Function to delete demo incidents
+delete_demo_incidents() {
+    echo -e "${YELLOW}Searching for existing demo incidents (correlation_id=${DEMO_CORRELATION_ID})...${NC}"
+
+    local deleted_count=0
+
+    # First, try to find incidents by correlation_id (new method)
+    local SEARCH_RESULT=$(curl -s \
+        -H "${AUTH_HEADER}" \
+        -H "Content-Type: application/json" \
+        "${INSTANCE_URL}/api/now/table/incident?sysparm_query=correlation_id=${DEMO_CORRELATION_ID}&sysparm_fields=sys_id,number,short_description")
+
+    # Extract sys_ids using Python
+    local SYS_IDS=$(echo "$SEARCH_RESULT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    results = data.get('result', [])
+    for r in results:
+        print(r.get('sys_id', ''), r.get('number', ''))
+except:
+    pass
+" 2>/dev/null)
+
+    # Delete each found incident
+    while IFS=' ' read -r sys_id inc_number; do
+        if [ -n "$sys_id" ]; then
+            echo -e "  ${YELLOW}Deleting: ${inc_number}${NC}"
+            local DELETE_RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+                -H "${AUTH_HEADER}" \
+                "${INSTANCE_URL}/api/now/table/incident/${sys_id}")
+
+            if [ "$DELETE_RESULT" = "204" ] || [ "$DELETE_RESULT" = "200" ]; then
+                echo -e "  ${GREEN}Deleted: ${inc_number}${NC}"
+                ((deleted_count++))
+            else
+                echo -e "  ${RED}Failed to delete ${inc_number} (HTTP ${DELETE_RESULT})${NC}"
+            fi
+        fi
+    done <<< "$SYS_IDS"
+
+    # Fallback: also search by short_description for older incidents without correlation_id
+    if [ $deleted_count -eq 0 ]; then
+        echo -e "${YELLOW}Checking for legacy demo incidents by description...${NC}"
+        for desc in "${DEMO_INCIDENTS[@]}"; do
+            local encoded_desc=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''${desc}'''))")
+
+            SEARCH_RESULT=$(curl -s \
+                -H "${AUTH_HEADER}" \
+                -H "Content-Type: application/json" \
+                "${INSTANCE_URL}/api/now/table/incident?sysparm_query=short_description=${encoded_desc}&sysparm_fields=sys_id,number,short_description")
+
+            SYS_IDS=$(echo "$SEARCH_RESULT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    results = data.get('result', [])
+    for r in results:
+        print(r.get('sys_id', ''), r.get('number', ''))
+except:
+    pass
+" 2>/dev/null)
+
+            while IFS=' ' read -r sys_id inc_number; do
+                if [ -n "$sys_id" ]; then
+                    echo -e "  ${YELLOW}Deleting: ${inc_number}${NC}"
+                    DELETE_RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+                        -H "${AUTH_HEADER}" \
+                        "${INSTANCE_URL}/api/now/table/incident/${sys_id}")
+
+                    if [ "$DELETE_RESULT" = "204" ] || [ "$DELETE_RESULT" = "200" ]; then
+                        echo -e "  ${GREEN}Deleted: ${inc_number}${NC}"
+                        ((deleted_count++))
+                    else
+                        echo -e "  ${RED}Failed to delete ${inc_number} (HTTP ${DELETE_RESULT})${NC}"
+                    fi
+                fi
+            done <<< "$SYS_IDS"
+        done
+    fi
+
+    if [ $deleted_count -gt 0 ]; then
+        echo -e "${GREEN}Deleted ${deleted_count} demo incident(s)${NC}"
+    else
+        echo -e "${YELLOW}No existing demo incidents found${NC}"
+    fi
+    echo ""
+}
+
+# Reset mode: delete existing demo incidents first
+if [ "$RESET_MODE" = true ]; then
+    echo -e "${BLUE}Reset mode enabled - deleting existing demo incidents...${NC}"
+    echo ""
+    delete_demo_incidents
+fi
+
+# Function to create an incident using a temp file for JSON
+create_incident() {
+    local short_desc="$1"
+    local description="$2"
+    local priority="$3"
+    local category="$4"
+    local subcategory="$5"
+    local urgency="$6"
+    local impact="$7"
+
+    echo -e "${YELLOW}Creating: ${short_desc}${NC}"
+
+    # Create JSON using Python to handle escaping properly
+    local json_payload=$(python3 -c "
+import json
+print(json.dumps({
+    'short_description': '''${short_desc}''',
+    'description': '''${description}''',
+    'priority': '${priority}',
+    'category': '${category}',
+    'subcategory': '${subcategory}',
+    'urgency': '${urgency}',
+    'impact': '${impact}'
+}))
+")
+
+    RESULT=$(curl -s -X POST \
+        -H "${AUTH_HEADER}" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json" \
+        "${INSTANCE_URL}/api/now/table/incident" \
+        -d "${json_payload}")
+
+    INC_NUMBER=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result',{}).get('number','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
+
+    if [ "$INC_NUMBER" != "UNKNOWN" ]; then
+        echo -e "${GREEN}  Created: ${INC_NUMBER}${NC}"
+    else
+        echo -e "${RED}  Failed to create incident${NC}"
+        echo "  Response: $RESULT"
+    fi
+}
+
+echo -e "${BLUE}Creating demo incidents...${NC}"
+echo ""
+
+# Incident 1: Critical database connection issue
+echo -e "${YELLOW}Creating: Database connection timeout on production cluster${NC}"
+RESULT=$(curl -s -X POST \
+    -H "${AUTH_HEADER}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    "${INSTANCE_URL}/api/now/table/incident" \
+    --data-raw '{"short_description":"Database connection timeout on production cluster","description":"Production database cluster experiencing intermittent connection timeouts. Error rate spiked to 15% starting at 14:00 UTC. Databricks ETL jobs are failing. Timeline: 13:55 UTC connection pool exhaustion, 13:56 UTC first ETL failures, 14:00 UTC error rate 15%. Affected: production-db-cluster-01, Daily ETL Pipeline (job 101). Max connections reached (500/500).","priority":"1","category":"Database","subcategory":"Performance","urgency":"1","impact":"1","correlation_id":"SUSE-AI-DEMO"}')
+INC_NUMBER=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result',{}).get('number','FAILED'))" 2>/dev/null || echo "FAILED")
+echo -e "${GREEN}  Created: ${INC_NUMBER}${NC}"
+
+# Incident 2: Databricks cluster scaling issue
+echo -e "${YELLOW}Creating: Databricks cluster auto-scaling failure${NC}"
+RESULT=$(curl -s -X POST \
+    -H "${AUTH_HEADER}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    "${INSTANCE_URL}/api/now/table/incident" \
+    --data-raw '{"short_description":"Databricks cluster auto-scaling failure","description":"Databricks production-etl-cluster failed to auto-scale during peak processing. Cluster stuck at 8 workers (max 16). Job queue depth: 45 pending jobs. Processing latency increased 3x. Cluster: production-etl-cluster (1234-567890-abc123), Spark 13.3.x-scala2.12.","priority":"2","category":"Cloud Infrastructure","subcategory":"Databricks","urgency":"2","impact":"2","correlation_id":"SUSE-AI-DEMO"}')
+INC_NUMBER=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result',{}).get('number','FAILED'))" 2>/dev/null || echo "FAILED")
+echo -e "${GREEN}  Created: ${INC_NUMBER}${NC}"
+
+# Incident 3: Data quality issue
+echo -e "${YELLOW}Creating: ETL pipeline data quality alert${NC}"
+RESULT=$(curl -s -X POST \
+    -H "${AUTH_HEADER}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    "${INSTANCE_URL}/api/now/table/incident" \
+    --data-raw '{"short_description":"ETL pipeline data quality alert","description":"Data quality checks failing on customer_transactions table. Null values in required fields. Table: main.production.customer_transactions. Failed records: 15000 (1.2%). Affected fields: customer_id, transaction_date. Root cause: upstream system sending incomplete records.","priority":"3","category":"Data Platform","subcategory":"ETL","urgency":"2","impact":"3","correlation_id":"SUSE-AI-DEMO"}')
+INC_NUMBER=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result',{}).get('number','FAILED'))" 2>/dev/null || echo "FAILED")
+echo -e "${GREEN}  Created: ${INC_NUMBER}${NC}"
+
+# Incident 4: ML model performance degradation
+echo -e "${YELLOW}Creating: ML model prediction accuracy degradation${NC}"
+RESULT=$(curl -s -X POST \
+    -H "${AUTH_HEADER}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    "${INSTANCE_URL}/api/now/table/incident" \
+    --data-raw '{"short_description":"ML model prediction accuracy degradation","description":"Production ML model showing degraded accuracy. F1 score dropped from 0.92 to 0.78 in 24 hours. Model: customer_churn_predictor_v3. Training cluster: ml-training-cluster. Last retrain: 7 days ago. Suspected: data drift, upstream quality issues, possible correlation with DB connectivity issues.","priority":"3","category":"Application","subcategory":"Machine Learning","urgency":"3","impact":"3","correlation_id":"SUSE-AI-DEMO"}')
+INC_NUMBER=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result',{}).get('number','FAILED'))" 2>/dev/null || echo "FAILED")
+echo -e "${GREEN}  Created: ${INC_NUMBER}${NC}"
+
+echo ""
+echo -e "${GREEN}╔══════════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║         Demo data loaded successfully!                           ║${NC}"
+echo -e "${GREEN}╚══════════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${BLUE}Demo incidents tagged with: correlation_id=${DEMO_CORRELATION_ID}${NC}"
+echo ""
+echo "To filter demo incidents in Claude Code, ask:"
+echo "  'List incidents with correlation_id SUSE-AI-DEMO'"
+echo "  'Show me all SUSE-AI-DEMO incidents'"
+echo ""
+echo "You can view the incidents at:"
+echo "  ${INSTANCE_URL}/nav_to.do?uri=incident_list.do"
+echo ""
+echo "Or query via API:"
+echo "  curl -H \"${AUTH_HEADER:0:20}...\" \\"
+echo "    \"${INSTANCE_URL}/api/now/table/incident?sysparm_query=correlation_id=${DEMO_CORRELATION_ID}\""

--- a/examples/servicenow-databricks-demo/scripts/register-adapters.sh
+++ b/examples/servicenow-databricks-demo/scripts/register-adapters.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+#
+# Register ServiceNow and Databricks MCP servers with the Universal Proxy
+#
+# This script registers the MCP servers as adapters so they can be accessed
+# through the Universal Proxy's unified endpoint.
+#
+# Usage:
+#   ./register-adapters.sh
+#   ./register-adapters.sh --proxy-url http://custom-proxy:8911
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env if it exists
+if [ -f "$PROJECT_DIR/.env" ]; then
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Default URLs - using k8s service DNS names
+PROXY_URL="${PROXY_URL:-http://localhost:8911}"
+SERVICENOW_ENDPOINT="${SERVICENOW_ENDPOINT:-http://servicenow-mcp.servicenow-databricks-demo.svc.cluster.local:8000/mcp}"
+DATABRICKS_ENDPOINT="${DATABRICKS_ENDPOINT:-http://databricks-mcp.servicenow-databricks-demo.svc.cluster.local:8001/mcp}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --proxy-url)
+            PROXY_URL="$2"
+            shift 2
+            ;;
+        --local)
+            # Use localhost endpoints (when port-forwarding all services)
+            SERVICENOW_ENDPOINT="http://localhost:8000/mcp"
+            DATABRICKS_ENDPOINT="http://localhost:8001/mcp"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+echo -e "${BLUE}"
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║         Registering MCP Adapters with Universal Proxy            ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+echo -e "${YELLOW}Proxy URL: ${PROXY_URL}${NC}"
+echo ""
+
+# Wait for proxy to be ready
+echo -e "${YELLOW}Checking proxy health...${NC}"
+for i in {1..30}; do
+    if curl -s "${PROXY_URL}/health" > /dev/null 2>&1; then
+        echo -e "${GREEN}Proxy is ready${NC}"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo -e "${RED}Proxy not responding at ${PROXY_URL}${NC}"
+        exit 1
+    fi
+    sleep 1
+done
+
+echo ""
+
+# Step 1: Register ServiceNow in the registry
+echo -e "${YELLOW}Step 1: Registering ServiceNow server in registry...${NC}"
+RESULT=$(curl -s -X POST "${PROXY_URL}/api/v1/registry/upload" \
+  -H "Content-Type: application/json" \
+  -H "X-User-ID: admin" \
+  -d "{
+    \"name\": \"servicenow\",
+    \"type\": \"remote\",
+    \"url\": \"${SERVICENOW_ENDPOINT}\",
+    \"meta\": {
+      \"category\": \"service-management\",
+      \"sidecarConfig\": {
+        \"commandType\": \"http\",
+        \"command\": \"${SERVICENOW_ENDPOINT}\"
+      },
+      \"tags\": [\"servicenow\", \"itsm\", \"incident-management\"]
+    },
+    \"about\": {
+      \"title\": \"ServiceNow ITSM\",
+      \"description\": \"ServiceNow MCP Server for incident management, CMDB queries, and ITSM workflows.\"
+    }
+  }" 2>&1)
+
+if echo "$RESULT" | grep -q '"id"' || echo "$RESULT" | grep -q '"name":"servicenow"' || echo "$RESULT" | grep -q 'already exists'; then
+    echo -e "${GREEN}ServiceNow server registered in registry${NC}"
+else
+    echo -e "${YELLOW}Registry response: ${RESULT}${NC}"
+fi
+
+echo ""
+
+# Step 2: Register Databricks in the registry
+echo -e "${YELLOW}Step 2: Registering Databricks server in registry...${NC}"
+RESULT=$(curl -s -X POST "${PROXY_URL}/api/v1/registry/upload" \
+  -H "Content-Type: application/json" \
+  -H "X-User-ID: admin" \
+  -d "{
+    \"name\": \"databricks\",
+    \"type\": \"remote\",
+    \"url\": \"${DATABRICKS_ENDPOINT}\",
+    \"meta\": {
+      \"category\": \"data-platform\",
+      \"sidecarConfig\": {
+        \"commandType\": \"http\",
+        \"command\": \"${DATABRICKS_ENDPOINT}\"
+      },
+      \"tags\": [\"databricks\", \"analytics\", \"data-platform\"]
+    },
+    \"about\": {
+      \"title\": \"Databricks\",
+      \"description\": \"Databricks MCP Server for cluster management, job monitoring, SQL queries, and analytics.\"
+    }
+  }" 2>&1)
+
+if echo "$RESULT" | grep -q '"id"' || echo "$RESULT" | grep -q '"name":"databricks"' || echo "$RESULT" | grep -q 'already exists'; then
+    echo -e "${GREEN}Databricks server registered in registry${NC}"
+else
+    echo -e "${YELLOW}Registry response: ${RESULT}${NC}"
+fi
+
+echo ""
+
+# Step 3: Create ServiceNow adapter
+echo -e "${YELLOW}Step 3: Creating ServiceNow adapter...${NC}"
+RESULT=$(curl -s -X POST "${PROXY_URL}/api/v1/adapters" \
+  -H "Content-Type: application/json" \
+  -H "X-User-ID: admin" \
+  -d "{
+    \"name\": \"servicenow\",
+    \"mcpServerId\": \"servicenow\"
+  }" 2>&1)
+
+if echo "$RESULT" | grep -q '"name":"servicenow"' || echo "$RESULT" | grep -q '"status":"ready"' || echo "$RESULT" | grep -q 'already exists'; then
+    echo -e "${GREEN}ServiceNow adapter created${NC}"
+    echo "  Endpoint: ${PROXY_URL}/api/v1/adapters/servicenow/mcp"
+else
+    echo -e "${YELLOW}Adapter response: ${RESULT}${NC}"
+fi
+
+echo ""
+
+# Step 4: Create Databricks adapter
+echo -e "${YELLOW}Step 4: Creating Databricks adapter...${NC}"
+RESULT=$(curl -s -X POST "${PROXY_URL}/api/v1/adapters" \
+  -H "Content-Type: application/json" \
+  -H "X-User-ID: admin" \
+  -d "{
+    \"name\": \"databricks\",
+    \"mcpServerId\": \"databricks\"
+  }" 2>&1)
+
+if echo "$RESULT" | grep -q '"name":"databricks"' || echo "$RESULT" | grep -q '"status":"ready"' || echo "$RESULT" | grep -q 'already exists'; then
+    echo -e "${GREEN}Databricks adapter created${NC}"
+    echo "  Endpoint: ${PROXY_URL}/api/v1/adapters/databricks/mcp"
+else
+    echo -e "${YELLOW}Adapter response: ${RESULT}${NC}"
+fi
+
+echo ""
+
+# List registered adapters
+echo -e "${YELLOW}Registered adapters:${NC}"
+curl -s "${PROXY_URL}/api/v1/adapters" -H "X-User-ID: admin" | jq -r '.[] | "  - \(.name): \(.status // "registered")"' 2>/dev/null || \
+curl -s "${PROXY_URL}/api/v1/adapters" -H "X-User-ID: admin"
+
+echo ""
+echo -e "${GREEN}Done! Access MCP servers through the proxy:${NC}"
+echo ""
+echo "  ServiceNow: ${PROXY_URL}/api/v1/adapters/servicenow/mcp"
+echo "  Databricks: ${PROXY_URL}/api/v1/adapters/databricks/mcp"
+echo ""
+echo -e "${YELLOW}Run the demo:${NC}"
+echo "  ./scripts/run-demo.sh --proxy"

--- a/examples/servicenow-databricks-demo/scripts/run-demo.sh
+++ b/examples/servicenow-databricks-demo/scripts/run-demo.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+#
+# Demo Script: Incident Correlation with ServiceNow + Databricks
+#
+# This script demonstrates the SUSE AI Universal Proxy's unified MCP endpoint
+# by making tool calls to both ServiceNow and Databricks through a single connection.
+#
+# Usage:
+#   ./run-demo.sh              # Interactive demo with pauses
+#   ./run-demo.sh --auto       # Automated demo (no pauses)
+#
+# Prerequisites:
+#   - Port forward running: kubectl port-forward -n servicenow-databricks-demo svc/suse-ai-proxy 8911:8911
+#   - Adapters registered: ./scripts/register-adapters.sh
+#   - Demo data loaded: ./scripts/load-servicenow-data.sh --reset
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load .env if it exists
+if [ -f "$DEMO_DIR/.env" ]; then
+    set -a
+    source "$DEMO_DIR/.env"
+    set +a
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Configuration
+PROXY_URL="${PROXY_URL:-http://localhost:8911}"
+UNIFIED_ENDPOINT="${PROXY_URL}/api/v1/mcp"
+AUTO_MODE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --auto)
+            AUTO_MODE=true
+            shift
+            ;;
+        --proxy-url)
+            PROXY_URL="$2"
+            UNIFIED_ENDPOINT="${PROXY_URL}/api/v1/mcp"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+pause() {
+    if [ "$AUTO_MODE" == "false" ]; then
+        echo ""
+        read -p "Press Enter to continue..."
+        echo ""
+    else
+        sleep 1
+    fi
+}
+
+section() {
+    echo ""
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}${CYAN}$1${NC}"
+    echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
+    echo ""
+}
+
+step() {
+    echo -e "${YELLOW}→ $1${NC}"
+}
+
+result() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+# MCP JSON-RPC helper - uses unified endpoint
+mcp_call() {
+    local tool_name=$1
+    local arguments=$2
+
+    curl -s -X POST "${UNIFIED_ENDPOINT}" \
+        -H "Content-Type: application/json" \
+        -H "X-User-ID: admin" \
+        -d "{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"tools/call\", \"params\": {\"name\": \"$tool_name\", \"arguments\": $arguments}}"
+}
+
+# Check services are running
+check_services() {
+    step "Checking proxy health..."
+
+    if ! curl -s "$PROXY_URL/health" > /dev/null 2>&1; then
+        echo -e "${RED}Universal Proxy not responding at $PROXY_URL${NC}"
+        echo "Run: kubectl port-forward -n servicenow-databricks-demo svc/suse-ai-proxy 8911:8911"
+        exit 1
+    fi
+    result "Universal Proxy: OK"
+
+    step "Checking unified MCP endpoint..."
+    TOOL_COUNT=$(curl -s -X POST "${UNIFIED_ENDPOINT}" \
+        -H "Content-Type: application/json" \
+        -H "X-User-ID: admin" \
+        -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}' | jq '.result.tools | length' 2>/dev/null || echo "0")
+
+    if [ "$TOOL_COUNT" -gt 0 ]; then
+        result "Unified endpoint: ${TOOL_COUNT} tools available"
+    else
+        echo -e "${RED}No tools available - are adapters registered?${NC}"
+        echo "Run: ./scripts/register-adapters.sh"
+        exit 1
+    fi
+    echo ""
+}
+
+# Demo start
+clear
+echo -e "${BLUE}"
+cat << 'EOF'
+╔══════════════════════════════════════════════════════════════════════════╗
+║                                                                          ║
+║    ███████╗██╗   ██╗███████╗███████╗     █████╗ ██╗                      ║
+║    ██╔════╝██║   ██║██╔════╝██╔════╝    ██╔══██╗██║                      ║
+║    ███████╗██║   ██║███████╗█████╗      ███████║██║                      ║
+║    ╚════██║██║   ██║╚════██║██╔══╝      ██╔══██║██║                      ║
+║    ███████║╚██████╔╝███████║███████╗    ██║  ██║██║                      ║
+║    ╚══════╝ ╚═════╝ ╚══════╝╚══════╝    ╚═╝  ╚═╝╚═╝                      ║
+║                                                                          ║
+║              Universal Proxy - Unified MCP Endpoint Demo                 ║
+║                     ServiceNow + Databricks                              ║
+║                                                                          ║
+╚══════════════════════════════════════════════════════════════════════════╝
+EOF
+echo -e "${NC}"
+
+echo -e "${GREEN}Unified MCP Endpoint: ${UNIFIED_ENDPOINT}${NC}"
+echo ""
+echo -e "${CYAN}This demo shows how a single MCP connection gives AI assistants"
+echo -e "access to multiple backend systems (ServiceNow + Databricks).${NC}"
+echo ""
+
+pause
+check_services
+
+# Scene 1: Show available tools
+section "Scene 1: Unified Tool Discovery"
+
+step "Listing all tools from unified endpoint..."
+echo ""
+echo -e "${CYAN}MCP Call: POST ${UNIFIED_ENDPOINT}${NC}"
+echo -e "${CYAN}Method: tools/list${NC}"
+echo ""
+
+curl -s -X POST "${UNIFIED_ENDPOINT}" \
+    -H "Content-Type: application/json" \
+    -H "X-User-ID: admin" \
+    -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}' | \
+    jq -r '.result.tools[] | "\(.name)"' 2>/dev/null | head -20
+
+echo ""
+echo -e "${GREEN}Note: Tools are prefixed with adapter name (servicenow__, databricks__)${NC}"
+
+pause
+
+# Scene 2: Search demo incidents
+section "Scene 2: Search Demo Incidents (ServiceNow)"
+
+step "Searching for demo incidents with correlation_id=SUSE-AI-DEMO..."
+echo ""
+echo -e "${CYAN}Tool: servicenow__search_incidents${NC}"
+echo ""
+
+RESULT=$(mcp_call "servicenow__search_incidents" '{"correlation_id": "SUSE-AI-DEMO"}')
+echo "$RESULT" | jq -r '.result.content[0].text' 2>/dev/null | jq -r '.incidents[] | "  \(.number): \(.short_description) (P\(.priority))"' 2>/dev/null || echo "$RESULT"
+
+pause
+
+# Scene 3: Get incident details
+section "Scene 3: Get Incident Details (ServiceNow)"
+
+# Get the first incident number from demo data
+INCIDENT=$(echo "$RESULT" | jq -r '.result.content[0].text' 2>/dev/null | jq -r '.incidents[0].number' 2>/dev/null || echo "INC0010014")
+
+step "Getting details for incident ${INCIDENT}..."
+echo ""
+echo -e "${CYAN}Tool: servicenow__get_incident${NC}"
+echo ""
+
+RESULT=$(mcp_call "servicenow__get_incident" "{\"incident_number\": \"${INCIDENT}\"}")
+echo "$RESULT" | jq -r '.result.content[0].text' 2>/dev/null | jq '{
+  number: .incident.number,
+  priority: .incident.priority,
+  state: .incident.state,
+  short_description: .incident.short_description,
+  description: .incident.description
+}' 2>/dev/null || echo "$RESULT" | head -50
+
+pause
+
+# Scene 4: Check Databricks error metrics
+section "Scene 4: Correlate with Databricks Error Metrics"
+
+step "Querying Databricks for error metrics during the incident timeframe..."
+echo ""
+echo -e "${CYAN}Tool: databricks__get_error_metrics${NC}"
+echo ""
+
+RESULT=$(mcp_call "databricks__get_error_metrics" '{"time_range": "last_6_hours"}')
+echo "$RESULT" | jq -r '.result.content[0].text' 2>/dev/null | jq '.' || echo "$RESULT" | head -30
+
+pause
+
+# Scene 5: Check system health
+section "Scene 5: Check System Health (Databricks)"
+
+step "Getting current system health metrics..."
+echo ""
+echo -e "${CYAN}Tool: databricks__get_system_health${NC}"
+echo ""
+
+RESULT=$(mcp_call "databricks__get_system_health" '{}')
+echo "$RESULT" | jq -r '.result.content[0].text' 2>/dev/null | jq '.' || echo "$RESULT" | head -30
+
+pause
+
+# Scene 6: Correlate events
+section "Scene 6: Cross-System Event Correlation"
+
+step "Running automated event correlation for the incident..."
+echo ""
+echo -e "${CYAN}Tool: databricks__correlate_events${NC}"
+echo ""
+
+RESULT=$(mcp_call "databricks__correlate_events" "{\"incident_id\": \"${INCIDENT}\"}")
+echo "$RESULT" | jq -r '.result.content[0].text' 2>/dev/null | jq '.' || echo "$RESULT" | head -40
+
+pause
+
+# Summary
+section "Demo Summary"
+
+echo -e "${GREEN}The SUSE AI Universal Proxy demonstrated:${NC}"
+echo ""
+echo "  1. ${BOLD}Unified MCP Endpoint${NC}"
+echo "     Single connection for all MCP servers: ${UNIFIED_ENDPOINT}"
+echo ""
+echo "  2. ${BOLD}Tool Aggregation${NC}"
+echo "     Tools from ServiceNow + Databricks available through one interface"
+echo "     Format: adapter__toolname (e.g., servicenow__search_incidents)"
+echo ""
+echo "  3. ${BOLD}Cross-Platform Queries${NC}"
+echo "     AI can query both ITSM and analytics without switching connections"
+echo ""
+echo "  4. ${BOLD}Incident Correlation${NC}"
+echo "     Correlated ServiceNow incident with Databricks error metrics"
+echo ""
+
+echo -e "${CYAN}For the interactive Claude Code demo, see: DEMO_SCRIPT.md${NC}"
+echo ""
+
+echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${GREEN}                    Demo Complete!                               ${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"

--- a/examples/servicenow-databricks-demo/scripts/setup-rancher-desktop.sh
+++ b/examples/servicenow-databricks-demo/scripts/setup-rancher-desktop.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+#
+# Setup script for ServiceNow + Databricks Demo on Rancher Desktop
+#
+# This script:
+# 1. Builds the MCP server container images
+# 2. Loads them into Rancher Desktop's k3s cluster
+# 3. Deploys the demo in mock or real mode
+#
+# Usage:
+#   # Mock mode (demo data)
+#   ./setup-rancher-desktop.sh
+#
+#   # Real mode with OAuth 2.0 (recommended)
+#   ./setup-rancher-desktop.sh --real \
+#     --servicenow-url "https://devXXXXX.service-now.com" \
+#     --servicenow-auth oauth \
+#     --servicenow-client-id "your_client_id" \
+#     --servicenow-client-secret "your_client_secret" \
+#     --databricks-host "https://dbc-xxxxx.cloud.databricks.com" \
+#     --databricks-token "dapi-xxxxx"
+#
+#   # Real mode with Personal Access Token
+#   ./setup-rancher-desktop.sh --real \
+#     --servicenow-url "https://devXXXXX.service-now.com" \
+#     --servicenow-auth pat \
+#     --servicenow-pat "your_personal_access_token" \
+#     --databricks-host "https://dbc-xxxxx.cloud.databricks.com" \
+#     --databricks-token "dapi-xxxxx"
+#
+#   # Real mode with Basic Auth (legacy)
+#   ./setup-rancher-desktop.sh --real \
+#     --servicenow-url "https://devXXXXX.service-now.com" \
+#     --servicenow-auth basic \
+#     --servicenow-user "admin" \
+#     --servicenow-pass "password" \
+#     --databricks-host "https://dbc-xxxxx.cloud.databricks.com" \
+#     --databricks-token "dapi-xxxxx"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(dirname "$SCRIPT_DIR")"
+K8S_DIR="$DEMO_DIR/k8s"
+SERVERS_DIR="$DEMO_DIR/servers"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+MODE="mock"
+SERVICENOW_INSTANCE_URL=""
+SERVICENOW_AUTH_METHOD="oauth"
+SERVICENOW_CLIENT_ID=""
+SERVICENOW_CLIENT_SECRET=""
+SERVICENOW_PAT=""
+SERVICENOW_USERNAME=""
+SERVICENOW_PASSWORD=""
+DATABRICKS_HOST=""
+DATABRICKS_TOKEN=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --real)
+            MODE="real"
+            shift
+            ;;
+        --servicenow-url)
+            SERVICENOW_INSTANCE_URL="$2"
+            shift 2
+            ;;
+        --servicenow-auth)
+            SERVICENOW_AUTH_METHOD="$2"
+            shift 2
+            ;;
+        --servicenow-client-id)
+            SERVICENOW_CLIENT_ID="$2"
+            shift 2
+            ;;
+        --servicenow-client-secret)
+            SERVICENOW_CLIENT_SECRET="$2"
+            shift 2
+            ;;
+        --servicenow-pat)
+            SERVICENOW_PAT="$2"
+            shift 2
+            ;;
+        --servicenow-user)
+            SERVICENOW_USERNAME="$2"
+            shift 2
+            ;;
+        --servicenow-pass)
+            SERVICENOW_PASSWORD="$2"
+            shift 2
+            ;;
+        --databricks-host)
+            DATABRICKS_HOST="$2"
+            shift 2
+            ;;
+        --databricks-token)
+            DATABRICKS_TOKEN="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --real                         Use real mode (connect to actual APIs)"
+            echo ""
+            echo "ServiceNow Options:"
+            echo "  --servicenow-url URL           ServiceNow instance URL"
+            echo "  --servicenow-auth METHOD       Auth method: oauth (default), pat, or basic"
+            echo ""
+            echo "  OAuth 2.0 (recommended):"
+            echo "  --servicenow-client-id ID      OAuth client ID"
+            echo "  --servicenow-client-secret SEC OAuth client secret"
+            echo ""
+            echo "  Personal Access Token:"
+            echo "  --servicenow-pat TOKEN         Personal access token"
+            echo ""
+            echo "  Basic Auth (legacy):"
+            echo "  --servicenow-user USER         Username"
+            echo "  --servicenow-pass PASS         Password"
+            echo ""
+            echo "Databricks Options:"
+            echo "  --databricks-host HOST         Databricks workspace URL"
+            echo "  --databricks-token TOKEN       Personal access token"
+            echo ""
+            echo "  --help, -h                     Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}"
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║     ServiceNow + Databricks Demo Setup for Rancher Desktop       ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# Check prerequisites
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+
+if ! command -v kubectl &> /dev/null; then
+    echo -e "${RED}Error: kubectl not found. Please install kubectl.${NC}"
+    exit 1
+fi
+
+if ! command -v nerdctl &> /dev/null && ! command -v docker &> /dev/null; then
+    echo -e "${RED}Error: Neither nerdctl nor docker found.${NC}"
+    echo "Please ensure Rancher Desktop is running with container runtime enabled."
+    exit 1
+fi
+
+# Determine container runtime
+if command -v nerdctl &> /dev/null; then
+    CONTAINER_CMD="nerdctl"
+    # Check if we need to use --namespace for Rancher Desktop
+    if nerdctl --namespace k8s.io images &> /dev/null; then
+        CONTAINER_CMD="nerdctl --namespace k8s.io"
+    fi
+else
+    CONTAINER_CMD="docker"
+fi
+
+echo -e "${GREEN}Using container runtime: $CONTAINER_CMD${NC}"
+
+# Check Kubernetes connectivity
+if ! kubectl cluster-info &> /dev/null; then
+    echo -e "${RED}Error: Cannot connect to Kubernetes cluster.${NC}"
+    echo "Please ensure Rancher Desktop is running and k3s is enabled."
+    exit 1
+fi
+
+echo -e "${GREEN}Connected to Kubernetes cluster${NC}"
+
+# Build container images
+echo ""
+echo -e "${YELLOW}Building MCP server images...${NC}"
+
+echo "Building ServiceNow MCP server..."
+$CONTAINER_CMD build -t servicenow-mcp:local -f "$SERVERS_DIR/Dockerfile.servicenow" "$SERVERS_DIR"
+
+echo "Building Databricks MCP server..."
+$CONTAINER_CMD build -t databricks-mcp:local -f "$SERVERS_DIR/Dockerfile.databricks" "$SERVERS_DIR"
+
+echo -e "${GREEN}Images built successfully${NC}"
+
+# Deploy to Kubernetes
+echo ""
+echo -e "${YELLOW}Deploying to Kubernetes (mode: $MODE)...${NC}"
+
+if [ "$MODE" == "real" ]; then
+    # Validate ServiceNow credentials based on auth method
+    if [ -z "$SERVICENOW_INSTANCE_URL" ]; then
+        echo -e "${RED}Error: ServiceNow instance URL required for real mode${NC}"
+        echo "Please provide --servicenow-url"
+        exit 1
+    fi
+
+    case "$SERVICENOW_AUTH_METHOD" in
+        oauth)
+            if [ -z "$SERVICENOW_CLIENT_ID" ] || [ -z "$SERVICENOW_CLIENT_SECRET" ]; then
+                echo -e "${RED}Error: OAuth requires client ID and secret${NC}"
+                echo "Please provide --servicenow-client-id and --servicenow-client-secret"
+                exit 1
+            fi
+            echo -e "${GREEN}ServiceNow auth: OAuth 2.0${NC}"
+            ;;
+        pat)
+            if [ -z "$SERVICENOW_PAT" ]; then
+                echo -e "${RED}Error: PAT auth requires personal access token${NC}"
+                echo "Please provide --servicenow-pat"
+                exit 1
+            fi
+            echo -e "${GREEN}ServiceNow auth: Personal Access Token${NC}"
+            ;;
+        basic)
+            if [ -z "$SERVICENOW_USERNAME" ] || [ -z "$SERVICENOW_PASSWORD" ]; then
+                echo -e "${RED}Error: Basic auth requires username and password${NC}"
+                echo "Please provide --servicenow-user and --servicenow-pass"
+                exit 1
+            fi
+            echo -e "${YELLOW}ServiceNow auth: Basic (legacy - consider OAuth or PAT)${NC}"
+            ;;
+        *)
+            echo -e "${RED}Error: Invalid auth method '$SERVICENOW_AUTH_METHOD'${NC}"
+            echo "Use: oauth, pat, or basic"
+            exit 1
+            ;;
+    esac
+
+    if [ -z "$DATABRICKS_HOST" ] || [ -z "$DATABRICKS_TOKEN" ]; then
+        echo -e "${RED}Error: Databricks credentials required for real mode${NC}"
+        echo "Please provide --databricks-host and --databricks-token"
+        exit 1
+    fi
+
+    # Generate secrets
+    echo "Generating secrets..."
+    export SERVICENOW_INSTANCE_URL SERVICENOW_AUTH_METHOD
+    export SERVICENOW_CLIENT_ID SERVICENOW_CLIENT_SECRET
+    export SERVICENOW_PAT SERVICENOW_USERNAME SERVICENOW_PASSWORD
+    export DATABRICKS_HOST DATABRICKS_TOKEN
+    bash "$K8S_DIR/overlays/real/generate-secrets.sh"
+
+    # Deploy with real overlay
+    kubectl apply -k "$K8S_DIR/overlays/real/"
+else
+    # Deploy with mock overlay
+    kubectl apply -k "$K8S_DIR/overlays/mock/"
+fi
+
+# Wait for deployments
+echo ""
+echo -e "${YELLOW}Waiting for deployments to be ready...${NC}"
+
+kubectl wait --for=condition=available --timeout=120s deployment/servicenow-mcp -n servicenow-databricks-demo
+kubectl wait --for=condition=available --timeout=120s deployment/databricks-mcp -n servicenow-databricks-demo
+
+echo -e "${GREEN}Deployments ready!${NC}"
+
+# Get service information
+echo ""
+echo -e "${BLUE}╔══════════════════════════════════════════════════════════════════╗"
+echo "║                        Demo Deployed!                             ║"
+echo "╚══════════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${GREEN}Mode: $MODE${NC}"
+if [ "$MODE" == "real" ]; then
+    echo -e "${GREEN}ServiceNow Auth: $SERVICENOW_AUTH_METHOD${NC}"
+fi
+echo ""
+echo "Services:"
+kubectl get svc -n servicenow-databricks-demo
+echo ""
+
+# Port forwarding instructions
+echo -e "${YELLOW}To access the MCP servers locally, run:${NC}"
+echo ""
+echo "  # ServiceNow MCP (port 8000)"
+echo "  kubectl port-forward svc/servicenow-mcp 8000:8000 -n servicenow-databricks-demo &"
+echo ""
+echo "  # Databricks MCP (port 8001)"
+echo "  kubectl port-forward svc/databricks-mcp 8001:8001 -n servicenow-databricks-demo &"
+echo ""
+echo -e "${YELLOW}Then test with:${NC}"
+echo "  curl http://localhost:8000/health"
+echo "  curl http://localhost:8001/health"
+echo ""
+echo -e "${YELLOW}Or run the demo script:${NC}"
+echo "  ./scripts/run-demo.sh"

--- a/examples/servicenow-databricks-demo/servers/Dockerfile.databricks
+++ b/examples/servicenow-databricks-demo/servers/Dockerfile.databricks
@@ -1,0 +1,21 @@
+# Dockerfile for Databricks MCP Server
+
+FROM registry.suse.com/bci/python:3.11
+
+WORKDIR /app
+
+# Install dependencies
+RUN pip install --no-cache-dir flask requests
+
+# Copy the server
+COPY databricks_mcp_server.py /app/
+
+# Expose port
+EXPOSE 8001
+
+# Health check (using Python since BCI base image is minimal)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')" || exit 1
+
+# Run server
+CMD ["python3", "databricks_mcp_server.py"]

--- a/examples/servicenow-databricks-demo/servers/Dockerfile.servicenow
+++ b/examples/servicenow-databricks-demo/servers/Dockerfile.servicenow
@@ -1,0 +1,21 @@
+# Dockerfile for ServiceNow MCP Server
+
+FROM registry.suse.com/bci/python:3.11
+
+WORKDIR /app
+
+# Install dependencies
+RUN pip install --no-cache-dir flask requests
+
+# Copy the server
+COPY servicenow_mcp_server.py /app/
+
+# Expose port
+EXPOSE 8000
+
+# Health check (using Python since BCI base image is minimal)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+# Run server
+CMD ["python3", "servicenow_mcp_server.py"]

--- a/examples/servicenow-databricks-demo/servers/databricks_mcp_server.py
+++ b/examples/servicenow-databricks-demo/servers/databricks_mcp_server.py
@@ -1,0 +1,934 @@
+#!/usr/bin/env python3
+"""
+Databricks MCP Server - Mock + Real Mode
+
+An MCP server that provides Databricks workspace, SQL, and job management tools.
+Supports both mock data for demos and real Databricks API connections.
+
+Environment Variables:
+    DATABRICKS_HOST: Databricks workspace URL (e.g., https://dbc-xxxxx.cloud.databricks.com)
+    DATABRICKS_TOKEN: Databricks personal access token
+    DATABRICKS_MOCK_MODE: Set to "true" for mock data (default: true)
+    MCP_HOST: Host to bind to (default: 0.0.0.0)
+    MCP_PORT: Port to bind to (default: 8001)
+
+Usage:
+    # Mock mode (default)
+    python databricks_mcp_server.py
+
+    # Real mode
+    DATABRICKS_MOCK_MODE=false \
+    DATABRICKS_HOST=https://dbc-xxxxx.cloud.databricks.com \
+    DATABRICKS_TOKEN=dapi-xxxxxxxx \
+    python databricks_mcp_server.py
+"""
+
+import json
+import os
+import requests
+from datetime import datetime, timedelta
+from flask import Flask, request, jsonify, Response
+from typing import Any, Dict, List, Optional
+import random
+
+app = Flask(__name__)
+
+# Configuration
+MOCK_MODE = os.environ.get("DATABRICKS_MOCK_MODE", "true").lower() == "true"
+DATABRICKS_HOST = os.environ.get("DATABRICKS_HOST", "")
+DATABRICKS_TOKEN = os.environ.get("DATABRICKS_TOKEN", "")
+HOST = os.environ.get("MCP_HOST", "0.0.0.0")
+PORT = int(os.environ.get("MCP_PORT", "8001"))
+
+# Mock data for demo purposes
+MOCK_CLUSTERS = [
+    {
+        "cluster_id": "1234-567890-abc123",
+        "cluster_name": "production-etl-cluster",
+        "state": "RUNNING",
+        "state_message": "",
+        "spark_version": "13.3.x-scala2.12",
+        "node_type_id": "i3.xlarge",
+        "num_workers": 8,
+        "autoscale": {"min_workers": 4, "max_workers": 16},
+        "creator_user_name": "data-team@company.com",
+        "start_time": (datetime.now() - timedelta(hours=12)).timestamp() * 1000,
+        "last_activity_time": (datetime.now() - timedelta(minutes=5)).timestamp() * 1000,
+        "cluster_memory_mb": 65536,
+        "cluster_cores": 32
+    },
+    {
+        "cluster_id": "2345-678901-bcd234",
+        "cluster_name": "ml-training-cluster",
+        "state": "TERMINATED",
+        "state_message": "Terminated by autoscale",
+        "spark_version": "13.3.x-ml-scala2.12",
+        "node_type_id": "p3.2xlarge",
+        "num_workers": 4,
+        "creator_user_name": "ml-team@company.com",
+        "start_time": (datetime.now() - timedelta(days=1)).timestamp() * 1000,
+        "terminated_time": (datetime.now() - timedelta(hours=2)).timestamp() * 1000,
+        "cluster_memory_mb": 131072,
+        "cluster_cores": 64
+    },
+    {
+        "cluster_id": "3456-789012-cde345",
+        "cluster_name": "analytics-interactive",
+        "state": "RUNNING",
+        "state_message": "",
+        "spark_version": "14.1.x-scala2.12",
+        "node_type_id": "m5.2xlarge",
+        "num_workers": 2,
+        "creator_user_name": "analytics@company.com",
+        "start_time": (datetime.now() - timedelta(hours=3)).timestamp() * 1000,
+        "last_activity_time": (datetime.now() - timedelta(minutes=15)).timestamp() * 1000,
+        "cluster_memory_mb": 32768,
+        "cluster_cores": 16
+    }
+]
+
+MOCK_JOBS = [
+    {
+        "job_id": 101,
+        "settings": {
+            "name": "Daily ETL Pipeline",
+            "schedule": {"quartz_cron_expression": "0 0 6 * * ?", "timezone_id": "UTC"},
+            "email_notifications": {"on_failure": ["data-team@company.com"]}
+        },
+        "created_time": (datetime.now() - timedelta(days=90)).timestamp() * 1000,
+        "creator_user_name": "data-team@company.com"
+    },
+    {
+        "job_id": 102,
+        "settings": {
+            "name": "Customer Analytics Refresh",
+            "schedule": {"quartz_cron_expression": "0 30 * * * ?", "timezone_id": "UTC"},
+            "email_notifications": {"on_failure": ["analytics@company.com"]}
+        },
+        "created_time": (datetime.now() - timedelta(days=60)).timestamp() * 1000,
+        "creator_user_name": "analytics@company.com"
+    },
+    {
+        "job_id": 103,
+        "settings": {
+            "name": "ML Model Retraining",
+            "schedule": {"quartz_cron_expression": "0 0 2 * * 0", "timezone_id": "UTC"},
+            "email_notifications": {"on_failure": ["ml-team@company.com"]}
+        },
+        "created_time": (datetime.now() - timedelta(days=30)).timestamp() * 1000,
+        "creator_user_name": "ml-team@company.com"
+    }
+]
+
+MOCK_JOB_RUNS = [
+    {
+        "run_id": 10001,
+        "job_id": 101,
+        "run_name": "Daily ETL Pipeline - 2024-01-15",
+        "state": {"life_cycle_state": "TERMINATED", "result_state": "FAILED", "state_message": "Connection timeout to database"},
+        "start_time": (datetime.now() - timedelta(hours=4)).timestamp() * 1000,
+        "end_time": (datetime.now() - timedelta(hours=3, minutes=45)).timestamp() * 1000,
+        "execution_duration": 900000,
+        "cluster_spec": {"existing_cluster_id": "1234-567890-abc123"},
+        "task": {"notebook_task": {"notebook_path": "/Production/ETL/main"}}
+    },
+    {
+        "run_id": 10002,
+        "job_id": 101,
+        "run_name": "Daily ETL Pipeline - 2024-01-14",
+        "state": {"life_cycle_state": "TERMINATED", "result_state": "SUCCESS"},
+        "start_time": (datetime.now() - timedelta(days=1, hours=4)).timestamp() * 1000,
+        "end_time": (datetime.now() - timedelta(days=1, hours=3)).timestamp() * 1000,
+        "execution_duration": 3600000,
+        "cluster_spec": {"existing_cluster_id": "1234-567890-abc123"},
+        "task": {"notebook_task": {"notebook_path": "/Production/ETL/main"}}
+    },
+    {
+        "run_id": 10003,
+        "job_id": 102,
+        "run_name": "Customer Analytics Refresh",
+        "state": {"life_cycle_state": "RUNNING", "state_message": "Running"},
+        "start_time": (datetime.now() - timedelta(minutes=30)).timestamp() * 1000,
+        "cluster_spec": {"existing_cluster_id": "3456-789012-cde345"},
+        "task": {"notebook_task": {"notebook_path": "/Analytics/CustomerRefresh"}}
+    }
+]
+
+MOCK_SQL_RESULTS = {
+    "error_metrics": {
+        "columns": ["hour", "error_count", "error_rate", "top_error_type"],
+        "data": [
+            ["2024-01-15 10:00", 45, 0.05, "ConnectionTimeout"],
+            ["2024-01-15 11:00", 120, 0.12, "ConnectionTimeout"],
+            ["2024-01-15 12:00", 230, 0.23, "ConnectionTimeout"],
+            ["2024-01-15 13:00", 180, 0.18, "ConnectionTimeout"],
+            ["2024-01-15 14:00", 350, 0.35, "ConnectionTimeout"],  # Spike!
+            ["2024-01-15 15:00", 280, 0.28, "ConnectionTimeout"]
+        ]
+    },
+    "system_metrics": {
+        "columns": ["metric_name", "current_value", "threshold", "status"],
+        "data": [
+            ["db_connection_pool_used", 95, 80, "CRITICAL"],
+            ["db_query_latency_p99_ms", 2500, 1000, "WARNING"],
+            ["db_active_connections", 450, 500, "WARNING"],
+            ["etl_records_processed", 1250000, 0, "OK"],
+            ["etl_failed_records", 15000, 1000, "CRITICAL"]
+        ]
+    },
+    "incident_correlation": {
+        "columns": ["timestamp", "event_type", "source", "details", "correlation_id"],
+        "data": [
+            ["2024-01-15 13:55:00", "DB_CONNECTION_POOL_EXHAUSTED", "production-db-cluster-01", "Max connections reached: 500/500", "CORR-001"],
+            ["2024-01-15 13:56:00", "ETL_JOB_FAILED", "Daily ETL Pipeline", "ConnectionTimeout after 30s", "CORR-001"],
+            ["2024-01-15 13:57:00", "ALERT_TRIGGERED", "PagerDuty", "P1 Alert: Database connectivity issue", "CORR-001"],
+            ["2024-01-15 14:00:00", "INCIDENT_CREATED", "ServiceNow", "INC0010001: Database connection timeout", "CORR-001"]
+        ]
+    }
+}
+
+MOCK_TABLES = [
+    {
+        "catalog": "main",
+        "schema": "production",
+        "name": "customer_transactions",
+        "table_type": "MANAGED",
+        "data_source_format": "DELTA",
+        "created_at": (datetime.now() - timedelta(days=365)).isoformat(),
+        "updated_at": (datetime.now() - timedelta(hours=1)).isoformat(),
+        "row_count": 125000000,
+        "storage_size_bytes": 45000000000
+    },
+    {
+        "catalog": "main",
+        "schema": "production",
+        "name": "system_events",
+        "table_type": "MANAGED",
+        "data_source_format": "DELTA",
+        "created_at": (datetime.now() - timedelta(days=180)).isoformat(),
+        "updated_at": (datetime.now() - timedelta(minutes=5)).isoformat(),
+        "row_count": 500000000,
+        "storage_size_bytes": 120000000000
+    },
+    {
+        "catalog": "main",
+        "schema": "analytics",
+        "name": "error_metrics_hourly",
+        "table_type": "MANAGED",
+        "data_source_format": "DELTA",
+        "created_at": (datetime.now() - timedelta(days=90)).isoformat(),
+        "updated_at": (datetime.now() - timedelta(hours=1)).isoformat(),
+        "row_count": 8760,
+        "storage_size_bytes": 50000000
+    }
+]
+
+# Tool definitions
+TOOLS = [
+    {
+        "name": "list_clusters",
+        "description": "List all Databricks clusters with their status and configuration",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "state_filter": {
+                    "type": "string",
+                    "description": "Filter by cluster state: RUNNING, TERMINATED, PENDING, etc."
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "get_cluster",
+        "description": "Get detailed information about a specific cluster",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "cluster_id": {
+                    "type": "string",
+                    "description": "The cluster ID"
+                }
+            },
+            "required": ["cluster_id"]
+        }
+    },
+    {
+        "name": "list_jobs",
+        "description": "List all Databricks jobs",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name_filter": {
+                    "type": "string",
+                    "description": "Filter jobs by name (partial match)"
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "get_job_runs",
+        "description": "Get recent runs for a specific job",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "integer",
+                    "description": "The job ID"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of runs to return (default: 10)"
+                },
+                "include_failed_only": {
+                    "type": "boolean",
+                    "description": "Only return failed runs"
+                }
+            },
+            "required": ["job_id"]
+        }
+    },
+    {
+        "name": "execute_sql",
+        "description": "Execute a SQL query on Databricks SQL warehouse and return results",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "SQL query to execute"
+                },
+                "warehouse_id": {
+                    "type": "string",
+                    "description": "SQL warehouse ID (optional, uses default if not specified)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum rows to return (default: 100)"
+                }
+            },
+            "required": ["query"]
+        }
+    },
+    {
+        "name": "get_error_metrics",
+        "description": "Get error metrics and rates from the analytics tables (commonly used for incident correlation)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "time_range": {
+                    "type": "string",
+                    "description": "Time range: last_hour, last_6_hours, last_day (default: last_6_hours)"
+                },
+                "source_system": {
+                    "type": "string",
+                    "description": "Filter by source system (e.g., 'database', 'etl', 'api')"
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "get_system_health",
+        "description": "Get current system health metrics including database connections, query latency, and processing status",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    },
+    {
+        "name": "correlate_events",
+        "description": "Find correlated events across systems for incident analysis",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "start_time": {
+                    "type": "string",
+                    "description": "Start time for correlation window (ISO format or relative like '-1h')"
+                },
+                "end_time": {
+                    "type": "string",
+                    "description": "End time for correlation window (ISO format or relative like 'now')"
+                },
+                "incident_id": {
+                    "type": "string",
+                    "description": "ServiceNow incident ID to correlate events for"
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "list_tables",
+        "description": "List tables in Unity Catalog",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "catalog": {
+                    "type": "string",
+                    "description": "Catalog name (default: main)"
+                },
+                "schema": {
+                    "type": "string",
+                    "description": "Schema name filter"
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "get_table_info",
+        "description": "Get detailed information about a table including schema, size, and recent updates",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "table_name": {
+                    "type": "string",
+                    "description": "Full table name (catalog.schema.table)"
+                }
+            },
+            "required": ["table_name"]
+        }
+    }
+]
+
+
+class DatabricksClient:
+    """Client for interacting with Databricks REST API"""
+
+    def __init__(self, host: str, token: str):
+        self.host = host.rstrip('/')
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json"
+        }
+
+    def _make_request(self, method: str, endpoint: str, params: Dict = None, data: Dict = None) -> Dict:
+        url = f"{self.host}/api/2.0/{endpoint}"
+        response = requests.request(
+            method=method,
+            url=url,
+            headers=self.headers,
+            params=params,
+            json=data,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json() if response.text else {}
+
+    def list_clusters(self) -> List[Dict]:
+        result = self._make_request("GET", "clusters/list")
+        return result.get("clusters", [])
+
+    def get_cluster(self, cluster_id: str) -> Dict:
+        result = self._make_request("GET", "clusters/get", params={"cluster_id": cluster_id})
+        return result
+
+    def list_jobs(self) -> List[Dict]:
+        result = self._make_request("GET", "jobs/list")
+        return result.get("jobs", [])
+
+    def get_job_runs(self, job_id: int, limit: int = 10) -> List[Dict]:
+        result = self._make_request("GET", "jobs/runs/list", params={"job_id": job_id, "limit": limit})
+        return result.get("runs", [])
+
+    def execute_sql(self, warehouse_id: str, query: str) -> Dict:
+        data = {
+            "warehouse_id": warehouse_id,
+            "statement": query,
+            "wait_timeout": "30s"
+        }
+        result = self._make_request("POST", "sql/statements", data=data)
+        return result
+
+
+def execute_tool_mock(name: str, arguments: Dict) -> Dict:
+    """Execute a tool using mock data"""
+
+    if name == "list_clusters":
+        results = MOCK_CLUSTERS.copy()
+        if arguments.get("state_filter"):
+            results = [c for c in results if c["state"] == arguments["state_filter"]]
+        return {"mode": "mock", "count": len(results), "clusters": results}
+
+    elif name == "get_cluster":
+        cluster_id = arguments.get("cluster_id", "")
+        for cluster in MOCK_CLUSTERS:
+            if cluster["cluster_id"] == cluster_id:
+                return {"mode": "mock", "cluster": cluster}
+        return {"error": f"Cluster {cluster_id} not found"}
+
+    elif name == "list_jobs":
+        results = MOCK_JOBS.copy()
+        if arguments.get("name_filter"):
+            filter_str = arguments["name_filter"].lower()
+            results = [j for j in results if filter_str in j["settings"]["name"].lower()]
+        return {"mode": "mock", "count": len(results), "jobs": results}
+
+    elif name == "get_job_runs":
+        job_id = arguments.get("job_id")
+        limit = arguments.get("limit", 10)
+        include_failed_only = arguments.get("include_failed_only", False)
+
+        results = [r for r in MOCK_JOB_RUNS if r["job_id"] == job_id]
+        if include_failed_only:
+            results = [r for r in results if r["state"].get("result_state") == "FAILED"]
+        results = results[:limit]
+
+        return {"mode": "mock", "job_id": job_id, "count": len(results), "runs": results}
+
+    elif name == "execute_sql":
+        query = arguments.get("query", "").lower()
+
+        # Return appropriate mock results based on query content
+        if "error" in query:
+            data = MOCK_SQL_RESULTS["error_metrics"]
+        elif "incident" in query or "correlat" in query:
+            data = MOCK_SQL_RESULTS["incident_correlation"]
+        else:
+            data = MOCK_SQL_RESULTS["system_metrics"]
+
+        return {
+            "mode": "mock",
+            "query": arguments.get("query"),
+            "result": {
+                "columns": data["columns"],
+                "data": data["data"],
+                "row_count": len(data["data"])
+            }
+        }
+
+    elif name == "get_error_metrics":
+        time_range = arguments.get("time_range", "last_6_hours")
+        data = MOCK_SQL_RESULTS["error_metrics"]
+
+        return {
+            "mode": "mock",
+            "time_range": time_range,
+            "source_system": arguments.get("source_system", "all"),
+            "summary": {
+                "total_errors": sum(row[1] for row in data["data"]),
+                "peak_error_rate": max(row[2] for row in data["data"]),
+                "peak_hour": [row for row in data["data"] if row[2] == max(r[2] for r in data["data"])][0][0],
+                "dominant_error_type": "ConnectionTimeout"
+            },
+            "hourly_data": [
+                {"hour": row[0], "error_count": row[1], "error_rate": row[2], "top_error": row[3]}
+                for row in data["data"]
+            ]
+        }
+
+    elif name == "get_system_health":
+        data = MOCK_SQL_RESULTS["system_metrics"]
+        metrics = {row[0]: {"value": row[1], "threshold": row[2], "status": row[3]} for row in data["data"]}
+
+        critical_count = sum(1 for row in data["data"] if row[3] == "CRITICAL")
+        warning_count = sum(1 for row in data["data"] if row[3] == "WARNING")
+
+        return {
+            "mode": "mock",
+            "overall_status": "CRITICAL" if critical_count > 0 else ("WARNING" if warning_count > 0 else "OK"),
+            "critical_issues": critical_count,
+            "warnings": warning_count,
+            "metrics": metrics
+        }
+
+    elif name == "correlate_events":
+        data = MOCK_SQL_RESULTS["incident_correlation"]
+
+        return {
+            "mode": "mock",
+            "correlation_window": {
+                "start": arguments.get("start_time", (datetime.now() - timedelta(hours=1)).isoformat()),
+                "end": arguments.get("end_time", datetime.now().isoformat())
+            },
+            "incident_id": arguments.get("incident_id", "INC0010001"),
+            "correlated_events": [
+                {
+                    "timestamp": row[0],
+                    "event_type": row[1],
+                    "source": row[2],
+                    "details": row[3],
+                    "correlation_id": row[4]
+                }
+                for row in data["data"]
+            ],
+            "root_cause_analysis": {
+                "probable_root_cause": "Database connection pool exhaustion",
+                "affected_systems": ["production-db-cluster-01", "Daily ETL Pipeline"],
+                "impact_duration_minutes": 35,
+                "recommendation": "Increase connection pool size and implement connection pooling optimization"
+            }
+        }
+
+    elif name == "list_tables":
+        results = MOCK_TABLES.copy()
+        if arguments.get("catalog"):
+            results = [t for t in results if t["catalog"] == arguments["catalog"]]
+        if arguments.get("schema"):
+            results = [t for t in results if t["schema"] == arguments["schema"]]
+
+        return {"mode": "mock", "count": len(results), "tables": results}
+
+    elif name == "get_table_info":
+        table_name = arguments.get("table_name", "")
+        parts = table_name.split(".")
+        if len(parts) == 3:
+            catalog, schema, name = parts
+            for table in MOCK_TABLES:
+                if table["catalog"] == catalog and table["schema"] == schema and table["name"] == name:
+                    return {"mode": "mock", "table": table}
+        return {"error": f"Table {table_name} not found"}
+
+    else:
+        return {"error": f"Unknown tool: {name}"}
+
+
+# Configuration for real mode analytics queries
+ANALYTICS_CATALOG = os.environ.get("DATABRICKS_CATALOG", "main")
+ANALYTICS_SCHEMA = os.environ.get("DATABRICKS_SCHEMA", "analytics")
+SQL_WAREHOUSE_ID = os.environ.get("DATABRICKS_WAREHOUSE_ID", "")
+
+
+def execute_tool_real(name: str, arguments: Dict, client: DatabricksClient) -> Dict:
+    """Execute a tool using real Databricks API"""
+
+    try:
+        if name == "list_clusters":
+            clusters = client.list_clusters()
+            if arguments.get("state_filter"):
+                clusters = [c for c in clusters if c.get("state") == arguments["state_filter"]]
+            return {"mode": "real", "count": len(clusters), "clusters": clusters}
+
+        elif name == "get_cluster":
+            cluster = client.get_cluster(arguments["cluster_id"])
+            return {"mode": "real", "cluster": cluster}
+
+        elif name == "list_jobs":
+            jobs = client.list_jobs()
+            if arguments.get("name_filter"):
+                filter_str = arguments["name_filter"].lower()
+                jobs = [j for j in jobs if filter_str in j.get("settings", {}).get("name", "").lower()]
+            return {"mode": "real", "count": len(jobs), "jobs": jobs}
+
+        elif name == "get_job_runs":
+            runs = client.get_job_runs(arguments["job_id"], arguments.get("limit", 10))
+            if arguments.get("include_failed_only"):
+                runs = [r for r in runs if r.get("state", {}).get("result_state") == "FAILED"]
+            return {"mode": "real", "job_id": arguments["job_id"], "count": len(runs), "runs": runs}
+
+        elif name == "execute_sql":
+            warehouse_id = arguments.get("warehouse_id") or SQL_WAREHOUSE_ID
+            if not warehouse_id:
+                return {"error": "warehouse_id is required. Set DATABRICKS_WAREHOUSE_ID or pass warehouse_id parameter."}
+            result = client.execute_sql(warehouse_id, arguments["query"])
+            return {"mode": "real", "query": arguments["query"], "result": result}
+
+        elif name == "get_error_metrics":
+            warehouse_id = SQL_WAREHOUSE_ID
+            if not warehouse_id:
+                return execute_tool_mock(name, arguments)
+
+            time_range = arguments.get("time_range", "last_6_hours")
+            hours_map = {"last_hour": 1, "last_6_hours": 6, "last_day": 24}
+            hours = hours_map.get(time_range, 6)
+
+            query = f"""
+                SELECT hour, error_count, error_rate, top_error_type, source_system
+                FROM {ANALYTICS_CATALOG}.{ANALYTICS_SCHEMA}.error_metrics_hourly
+                WHERE timestamp >= current_timestamp() - INTERVAL {hours} HOURS
+                ORDER BY timestamp DESC
+            """
+            result = client.execute_sql(warehouse_id, query)
+
+            # Parse SQL result - values come back as strings from SQL API
+            data = result.get("result", {}).get("data_array", [])
+            if data:
+                total_errors = sum(int(row[1]) for row in data if row[1])
+                peak_rate = max((float(row[2]) for row in data if row[2]), default=0)
+                return {
+                    "mode": "real",
+                    "time_range": time_range,
+                    "summary": {
+                        "total_errors": total_errors,
+                        "peak_error_rate": peak_rate,
+                        "data_points": len(data)
+                    },
+                    "hourly_data": [
+                        {"hour": row[0], "error_count": row[1], "error_rate": row[2], "top_error": row[3], "source": row[4]}
+                        for row in data
+                    ]
+                }
+            return {"mode": "real", "time_range": time_range, "hourly_data": [], "message": "No data found"}
+
+        elif name == "get_system_health":
+            warehouse_id = SQL_WAREHOUSE_ID
+            if not warehouse_id:
+                return execute_tool_mock(name, arguments)
+
+            query = f"""
+                SELECT metric_name, current_value, threshold, status, component
+                FROM {ANALYTICS_CATALOG}.{ANALYTICS_SCHEMA}.system_health
+                WHERE timestamp >= current_timestamp() - INTERVAL 1 HOUR
+                ORDER BY timestamp DESC
+            """
+            result = client.execute_sql(warehouse_id, query)
+
+            data = result.get("result", {}).get("data_array", [])
+            metrics = {}
+            critical_count = 0
+            warning_count = 0
+
+            for row in data:
+                metric_name, value, threshold, status, component = row
+                metrics[metric_name] = {"value": value, "threshold": threshold, "status": status, "component": component}
+                if status == "CRITICAL":
+                    critical_count += 1
+                elif status == "WARNING":
+                    warning_count += 1
+
+            return {
+                "mode": "real",
+                "overall_status": "CRITICAL" if critical_count > 0 else ("WARNING" if warning_count > 0 else "OK"),
+                "critical_issues": critical_count,
+                "warnings": warning_count,
+                "metrics": metrics
+            }
+
+        elif name == "correlate_events":
+            warehouse_id = SQL_WAREHOUSE_ID
+            if not warehouse_id:
+                return execute_tool_mock(name, arguments)
+
+            incident_id = arguments.get("incident_id", "")
+            hours = 2  # Default correlation window
+
+            # Build query - filter by incident_id if provided
+            if incident_id:
+                query = f"""
+                    SELECT event_id, timestamp, event_type, source, details, severity, correlation_id
+                    FROM {ANALYTICS_CATALOG}.{ANALYTICS_SCHEMA}.system_events
+                    WHERE details LIKE '%{incident_id}%'
+                       OR correlation_id IN (
+                           SELECT DISTINCT correlation_id
+                           FROM {ANALYTICS_CATALOG}.{ANALYTICS_SCHEMA}.system_events
+                           WHERE details LIKE '%{incident_id}%'
+                       )
+                    ORDER BY timestamp ASC
+                """
+            else:
+                query = f"""
+                    SELECT event_id, timestamp, event_type, source, details, severity, correlation_id
+                    FROM {ANALYTICS_CATALOG}.{ANALYTICS_SCHEMA}.system_events
+                    WHERE timestamp >= current_timestamp() - INTERVAL {hours} HOURS
+                    ORDER BY timestamp ASC
+                """
+
+            result = client.execute_sql(warehouse_id, query)
+            data = result.get("result", {}).get("data_array", [])
+
+            return {
+                "mode": "real",
+                "incident_id": incident_id or "all",
+                "event_count": len(data),
+                "correlated_events": [
+                    {
+                        "event_id": row[0],
+                        "timestamp": str(row[1]),
+                        "event_type": row[2],
+                        "source": row[3],
+                        "details": row[4],
+                        "severity": row[5],
+                        "correlation_id": row[6]
+                    }
+                    for row in data
+                ]
+            }
+
+        elif name == "list_tables":
+            warehouse_id = SQL_WAREHOUSE_ID
+            if not warehouse_id:
+                return execute_tool_mock(name, arguments)
+
+            catalog = arguments.get("catalog", ANALYTICS_CATALOG)
+            schema = arguments.get("schema", "")
+
+            if schema:
+                query = f"SHOW TABLES IN {catalog}.{schema}"
+            else:
+                query = f"SHOW TABLES IN {catalog}"
+
+            result = client.execute_sql(warehouse_id, query)
+            data = result.get("result", {}).get("data_array", [])
+
+            return {
+                "mode": "real",
+                "catalog": catalog,
+                "schema": schema or "all",
+                "tables": [{"database": row[0], "tableName": row[1], "isTemporary": row[2]} for row in data]
+            }
+
+        elif name == "get_table_info":
+            warehouse_id = SQL_WAREHOUSE_ID
+            if not warehouse_id:
+                return execute_tool_mock(name, arguments)
+
+            table_name = arguments.get("table_name", "")
+            query = f"DESCRIBE TABLE EXTENDED {table_name}"
+            result = client.execute_sql(warehouse_id, query)
+
+            return {
+                "mode": "real",
+                "table_name": table_name,
+                "schema": result.get("result", {}).get("data_array", [])
+            }
+
+        else:
+            return {"error": f"Unknown tool: {name}"}
+
+    except requests.exceptions.RequestException as e:
+        return {"error": f"Databricks API error: {str(e)}"}
+
+
+def handle_jsonrpc(data: Dict) -> Optional[Dict]:
+    """Handle a JSON-RPC request"""
+    method = data.get("method", "")
+    params = data.get("params", {})
+    req_id = data.get("id")
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "serverInfo": {
+                    "name": "databricks-mcp-server",
+                    "version": "1.0.0"
+                },
+                "capabilities": {
+                    "tools": {"listChanged": False},
+                    "resources": {"listChanged": False},
+                    "prompts": {"listChanged": False}
+                }
+            }
+        }
+
+    elif method == "initialized":
+        return None
+
+    elif method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"tools": TOOLS}
+        }
+
+    elif method == "tools/call":
+        tool_name = params.get("name", "")
+        arguments = params.get("arguments", {})
+
+        if MOCK_MODE:
+            result = execute_tool_mock(tool_name, arguments)
+        else:
+            client = DatabricksClient(DATABRICKS_HOST, DATABRICKS_TOKEN)
+            result = execute_tool_real(tool_name, arguments, client)
+
+        if "error" in result:
+            content = [{"type": "text", "text": f"Error: {result['error']}"}]
+            is_error = True
+        else:
+            content = [{"type": "text", "text": json.dumps(result, indent=2, default=str)}]
+            is_error = False
+
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"content": content, "isError": is_error}
+        }
+
+    elif method == "resources/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"resources": []}
+        }
+
+    elif method == "prompts/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"prompts": []}
+        }
+
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Method not found: {method}"}
+        }
+
+
+@app.route('/mcp', methods=['POST', 'GET'])
+def mcp_endpoint():
+    """Main MCP endpoint"""
+    if request.method == 'GET':
+        return Response("SSE not implemented", status=501)
+
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No JSON data"}), 400
+
+        response = handle_jsonrpc(data)
+
+        if response is None:
+            return '', 200
+
+        resp = jsonify(response)
+        resp.headers['MCP-Protocol-Version'] = '2025-06-18'
+        return resp
+
+    except Exception as e:
+        return jsonify({
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32700, "message": str(e)}
+        }), 500
+
+
+@app.route('/health', methods=['GET'])
+def health():
+    return jsonify({
+        "status": "healthy",
+        "mode": "mock" if MOCK_MODE else "real",
+        "databricks_host": DATABRICKS_HOST if not MOCK_MODE else "N/A (mock mode)"
+    })
+
+
+if __name__ == '__main__':
+    print("=" * 70)
+    print("  Databricks MCP Server")
+    print("=" * 70)
+    print()
+    print(f"  Mode: {'MOCK (demo data)' if MOCK_MODE else 'REAL (Databricks API)'}")
+    if not MOCK_MODE:
+        print(f"  Host: {DATABRICKS_HOST}")
+    print()
+    print("  Available tools:")
+    for tool in TOOLS:
+        print(f"    - {tool['name']}: {tool['description'][:55]}...")
+    print()
+    print(f"  Server running at: http://{HOST}:{PORT}/mcp")
+    print()
+    print("  Environment variables:")
+    print("    DATABRICKS_MOCK_MODE=true|false (default: true)")
+    print("    DATABRICKS_HOST=https://your-workspace.cloud.databricks.com")
+    print("    DATABRICKS_TOKEN=dapi-xxxxx")
+    print()
+    print("  Press Ctrl+C to stop")
+    print()
+
+    app.run(host=HOST, port=PORT, debug=False)

--- a/examples/servicenow-databricks-demo/servers/servicenow_mcp_server.py
+++ b/examples/servicenow-databricks-demo/servers/servicenow_mcp_server.py
@@ -1,0 +1,894 @@
+#!/usr/bin/env python3
+"""
+ServiceNow MCP Server - Mock + Real Mode
+
+An MCP server that provides ServiceNow incident management tools.
+Supports both mock data for demos and real ServiceNow API connections.
+
+Authentication Methods:
+    1. OAuth 2.0 Client Credentials (Recommended)
+    2. Personal Access Token (PAT) - San Diego release and later
+    3. Basic Auth (username/password) - Legacy
+
+Environment Variables:
+    SERVICENOW_INSTANCE_URL: ServiceNow instance URL (e.g., https://dev12345.service-now.com)
+    SERVICENOW_AUTH_METHOD: Authentication method: "oauth", "pat", or "basic" (default: "oauth")
+
+    # For OAuth 2.0 (recommended):
+    SERVICENOW_CLIENT_ID: OAuth client ID
+    SERVICENOW_CLIENT_SECRET: OAuth client secret
+
+    # For Personal Access Token:
+    SERVICENOW_PAT: Personal Access Token
+
+    # For Basic Auth (legacy):
+    SERVICENOW_USERNAME: ServiceNow username
+    SERVICENOW_PASSWORD: ServiceNow password
+
+    SERVICENOW_MOCK_MODE: Set to "true" for mock data (default: true)
+    MCP_HOST: Host to bind to (default: 0.0.0.0)
+    MCP_PORT: Port to bind to (default: 8000)
+
+Usage:
+    # Mock mode (default)
+    python servicenow_mcp_server.py
+
+    # Real mode with OAuth 2.0 (recommended)
+    SERVICENOW_MOCK_MODE=false \
+    SERVICENOW_INSTANCE_URL=https://dev12345.service-now.com \
+    SERVICENOW_AUTH_METHOD=oauth \
+    SERVICENOW_CLIENT_ID=your_client_id \
+    SERVICENOW_CLIENT_SECRET=your_client_secret \
+    python servicenow_mcp_server.py
+
+    # Real mode with Personal Access Token
+    SERVICENOW_MOCK_MODE=false \
+    SERVICENOW_INSTANCE_URL=https://dev12345.service-now.com \
+    SERVICENOW_AUTH_METHOD=pat \
+    SERVICENOW_PAT=your_personal_access_token \
+    python servicenow_mcp_server.py
+
+    # Real mode with Basic Auth (legacy)
+    SERVICENOW_MOCK_MODE=false \
+    SERVICENOW_INSTANCE_URL=https://dev12345.service-now.com \
+    SERVICENOW_AUTH_METHOD=basic \
+    SERVICENOW_USERNAME=admin \
+    SERVICENOW_PASSWORD=password \
+    python servicenow_mcp_server.py
+"""
+
+import json
+import os
+import requests
+from datetime import datetime, timedelta
+from flask import Flask, request, jsonify, Response
+from typing import Any, Dict, List, Optional
+import random
+import threading
+
+app = Flask(__name__)
+
+# Configuration
+MOCK_MODE = os.environ.get("SERVICENOW_MOCK_MODE", "true").lower() == "true"
+INSTANCE_URL = os.environ.get("SERVICENOW_INSTANCE_URL", "")
+AUTH_METHOD = os.environ.get("SERVICENOW_AUTH_METHOD", "oauth").lower()
+
+# OAuth 2.0 credentials
+CLIENT_ID = os.environ.get("SERVICENOW_CLIENT_ID", "")
+CLIENT_SECRET = os.environ.get("SERVICENOW_CLIENT_SECRET", "")
+
+# Personal Access Token
+PAT = os.environ.get("SERVICENOW_PAT", "")
+
+# Basic Auth (legacy)
+USERNAME = os.environ.get("SERVICENOW_USERNAME", "")
+PASSWORD = os.environ.get("SERVICENOW_PASSWORD", "")
+HOST = os.environ.get("MCP_HOST", "0.0.0.0")
+PORT = int(os.environ.get("MCP_PORT", "8000"))
+
+# Mock data for demo purposes
+MOCK_INCIDENTS = [
+    {
+        "number": "INC0010001",
+        "short_description": "Database connection timeout on production cluster",
+        "priority": "1",
+        "state": "2",  # In Progress
+        "category": "Database",
+        "subcategory": "Performance",
+        "assigned_to": "John Smith",
+        "assignment_group": "Database Operations",
+        "sys_created_on": (datetime.now() - timedelta(hours=4)).isoformat(),
+        "sys_updated_on": (datetime.now() - timedelta(minutes=30)).isoformat(),
+        "caller_id": "Jane Doe",
+        "impact": "1",
+        "urgency": "1",
+        "description": "Production database cluster experiencing intermittent connection timeouts. Error rate spiked to 15% starting at 14:00 UTC. Databricks ETL jobs are failing.",
+        "work_notes": "Investigating connection pool settings. Initial analysis shows max connections reached."
+    },
+    {
+        "number": "INC0010002",
+        "short_description": "Databricks cluster auto-scaling failure",
+        "priority": "2",
+        "state": "1",  # New
+        "category": "Cloud Infrastructure",
+        "subcategory": "Databricks",
+        "assigned_to": "",
+        "assignment_group": "Cloud Platform Team",
+        "sys_created_on": (datetime.now() - timedelta(hours=2)).isoformat(),
+        "sys_updated_on": (datetime.now() - timedelta(hours=2)).isoformat(),
+        "caller_id": "Mike Johnson",
+        "impact": "2",
+        "urgency": "2",
+        "description": "Databricks cluster failed to auto-scale during peak processing. Jobs queuing up.",
+        "work_notes": ""
+    },
+    {
+        "number": "INC0010003",
+        "short_description": "ETL pipeline data quality alert",
+        "priority": "3",
+        "state": "2",  # In Progress
+        "category": "Data Platform",
+        "subcategory": "ETL",
+        "assigned_to": "Sarah Wilson",
+        "assignment_group": "Data Engineering",
+        "sys_created_on": (datetime.now() - timedelta(days=1)).isoformat(),
+        "sys_updated_on": (datetime.now() - timedelta(hours=6)).isoformat(),
+        "caller_id": "Data Quality Monitor",
+        "impact": "3",
+        "urgency": "2",
+        "description": "Data quality checks failing on customer_transactions table. Null values detected in required fields.",
+        "work_notes": "Root cause identified: upstream system sending incomplete records."
+    },
+    {
+        "number": "INC0010004",
+        "short_description": "API gateway latency spike",
+        "priority": "2",
+        "state": "6",  # Resolved
+        "category": "Application",
+        "subcategory": "API",
+        "assigned_to": "Tom Brown",
+        "assignment_group": "API Platform",
+        "sys_created_on": (datetime.now() - timedelta(days=2)).isoformat(),
+        "sys_updated_on": (datetime.now() - timedelta(hours=12)).isoformat(),
+        "caller_id": "Monitoring System",
+        "impact": "2",
+        "urgency": "2",
+        "description": "API gateway P99 latency exceeded 500ms threshold.",
+        "work_notes": "Resolved by scaling up API gateway pods and optimizing database queries."
+    },
+    {
+        "number": "INC0010005",
+        "short_description": "ML model serving degraded performance",
+        "priority": "2",
+        "state": "2",  # In Progress
+        "category": "Machine Learning",
+        "subcategory": "Model Serving",
+        "assigned_to": "Lisa Chen",
+        "assignment_group": "ML Platform",
+        "sys_created_on": (datetime.now() - timedelta(hours=8)).isoformat(),
+        "sys_updated_on": (datetime.now() - timedelta(hours=1)).isoformat(),
+        "caller_id": "ML Pipeline Monitor",
+        "impact": "2",
+        "urgency": "2",
+        "description": "Recommendation model serving latency increased 3x. Affecting customer experience on e-commerce platform.",
+        "work_notes": "Investigating model complexity and feature store performance."
+    }
+]
+
+MOCK_CMDB_CIS = [
+    {
+        "sys_id": "ci001",
+        "name": "prod-db-cluster-01",
+        "sys_class_name": "cmdb_ci_database",
+        "operational_status": "1",
+        "environment": "Production",
+        "location": "US-East-1",
+        "assigned_to": "Database Operations",
+        "comments": "Primary production database cluster"
+    },
+    {
+        "sys_id": "ci002",
+        "name": "databricks-workspace-prod",
+        "sys_class_name": "cmdb_ci_cloud_service",
+        "operational_status": "1",
+        "environment": "Production",
+        "location": "US-East-1",
+        "assigned_to": "Cloud Platform Team",
+        "comments": "Production Databricks workspace for analytics"
+    },
+    {
+        "sys_id": "ci003",
+        "name": "etl-pipeline-main",
+        "sys_class_name": "cmdb_ci_service",
+        "operational_status": "1",
+        "environment": "Production",
+        "location": "US-East-1",
+        "assigned_to": "Data Engineering",
+        "comments": "Main ETL data pipeline"
+    }
+]
+
+# State and priority mappings
+STATE_MAP = {
+    "1": "New",
+    "2": "In Progress",
+    "3": "On Hold",
+    "6": "Resolved",
+    "7": "Closed"
+}
+
+PRIORITY_MAP = {
+    "1": "Critical",
+    "2": "High",
+    "3": "Medium",
+    "4": "Low",
+    "5": "Planning"
+}
+
+# Tool definitions
+TOOLS = [
+    {
+        "name": "search_incidents",
+        "description": "Search for ServiceNow incidents by various criteria (priority, state, category, assignment group, correlation_id)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Free text search query"
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "Filter by priority: 1 (Critical), 2 (High), 3 (Medium), 4 (Low)"
+                },
+                "state": {
+                    "type": "string",
+                    "description": "Filter by state: 1 (New), 2 (In Progress), 3 (On Hold), 6 (Resolved), 7 (Closed)"
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Filter by category (e.g., Database, Cloud Infrastructure, Data Platform)"
+                },
+                "assignment_group": {
+                    "type": "string",
+                    "description": "Filter by assignment group"
+                },
+                "correlation_id": {
+                    "type": "string",
+                    "description": "Filter by correlation ID (e.g., SUSE-AI-DEMO for demo incidents)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 10)"
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "get_incident",
+        "description": "Get detailed information about a specific incident by its number",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "incident_number": {
+                    "type": "string",
+                    "description": "The incident number (e.g., INC0010001)"
+                }
+            },
+            "required": ["incident_number"]
+        }
+    },
+    {
+        "name": "create_incident",
+        "description": "Create a new incident in ServiceNow",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "short_description": {
+                    "type": "string",
+                    "description": "Brief description of the incident"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Detailed description of the incident"
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "Priority level: 1 (Critical), 2 (High), 3 (Medium), 4 (Low)"
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Incident category"
+                },
+                "assignment_group": {
+                    "type": "string",
+                    "description": "Group to assign the incident to"
+                },
+                "caller_id": {
+                    "type": "string",
+                    "description": "Name of the person reporting the incident"
+                }
+            },
+            "required": ["short_description", "description"]
+        }
+    },
+    {
+        "name": "update_incident",
+        "description": "Update an existing incident (add work notes, change state, etc.)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "incident_number": {
+                    "type": "string",
+                    "description": "The incident number to update"
+                },
+                "state": {
+                    "type": "string",
+                    "description": "New state: 1 (New), 2 (In Progress), 3 (On Hold), 6 (Resolved), 7 (Closed)"
+                },
+                "work_notes": {
+                    "type": "string",
+                    "description": "Work notes to add to the incident"
+                },
+                "assigned_to": {
+                    "type": "string",
+                    "description": "Person to assign the incident to"
+                }
+            },
+            "required": ["incident_number"]
+        }
+    },
+    {
+        "name": "get_related_cis",
+        "description": "Get Configuration Items (CIs) related to an incident",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "incident_number": {
+                    "type": "string",
+                    "description": "The incident number"
+                }
+            },
+            "required": ["incident_number"]
+        }
+    },
+    {
+        "name": "search_cmdb",
+        "description": "Search the CMDB for configuration items",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query for CI name or description"
+                },
+                "ci_class": {
+                    "type": "string",
+                    "description": "CI class to filter by (e.g., cmdb_ci_database, cmdb_ci_server)"
+                },
+                "environment": {
+                    "type": "string",
+                    "description": "Environment filter (e.g., Production, Development)"
+                }
+            },
+            "required": []
+        }
+    },
+    {
+        "name": "get_incident_metrics",
+        "description": "Get aggregate metrics about incidents (counts by priority, state, category)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "time_range": {
+                    "type": "string",
+                    "description": "Time range: last_hour, last_day, last_week (default: last_day)"
+                }
+            },
+            "required": []
+        }
+    }
+]
+
+
+class ServiceNowClient:
+    """Client for interacting with ServiceNow REST API
+
+    Supports multiple authentication methods:
+    - OAuth 2.0 Client Credentials (recommended)
+    - Personal Access Token (PAT)
+    - Basic Auth (legacy)
+    """
+
+    def __init__(self, instance_url: str, auth_method: str = "oauth",
+                 client_id: str = None, client_secret: str = None,
+                 pat: str = None, username: str = None, password: str = None):
+        self.instance_url = instance_url.rstrip('/')
+        self.auth_method = auth_method
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.pat = pat
+        self.username = username
+        self.password = password
+
+        # OAuth token cache
+        self._oauth_token = None
+        self._token_expiry = None
+        self._token_lock = threading.Lock()
+
+        self.headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+
+    def _get_oauth_token(self) -> str:
+        """Get OAuth 2.0 access token using client credentials grant"""
+        with self._token_lock:
+            # Check if we have a valid cached token
+            if self._oauth_token and self._token_expiry:
+                if datetime.now() < self._token_expiry:
+                    return self._oauth_token
+
+            # Request new token
+            token_url = f"{self.instance_url}/oauth_token.do"
+            data = {
+                "grant_type": "client_credentials",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret
+            }
+
+            response = requests.post(token_url, data=data, timeout=30)
+            response.raise_for_status()
+            token_data = response.json()
+
+            self._oauth_token = token_data["access_token"]
+            # Set expiry with 60 second buffer
+            expires_in = token_data.get("expires_in", 1800)
+            self._token_expiry = datetime.now() + timedelta(seconds=expires_in - 60)
+
+            return self._oauth_token
+
+    def _get_auth_headers(self) -> Dict[str, str]:
+        """Get authentication headers based on auth method"""
+        headers = self.headers.copy()
+
+        if self.auth_method == "oauth":
+            token = self._get_oauth_token()
+            headers["Authorization"] = f"Bearer {token}"
+        elif self.auth_method == "pat":
+            headers["Authorization"] = f"Bearer {self.pat}"
+        # For basic auth, we use the auth parameter in requests
+
+        return headers
+
+    def _make_request(self, method: str, endpoint: str, params: Dict = None, data: Dict = None) -> Dict:
+        url = f"{self.instance_url}/api/now/{endpoint}"
+        headers = self._get_auth_headers()
+
+        # Use basic auth tuple only for basic auth method
+        auth = None
+        if self.auth_method == "basic":
+            auth = (self.username, self.password)
+
+        response = requests.request(
+            method=method,
+            url=url,
+            auth=auth,
+            headers=headers,
+            params=params,
+            json=data,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def search_incidents(self, query: str = None, priority: str = None, state: str = None,
+                        category: str = None, assignment_group: str = None,
+                        correlation_id: str = None, limit: int = 10) -> List[Dict]:
+        sysparm_query_parts = []
+
+        if query:
+            sysparm_query_parts.append(f"short_descriptionLIKE{query}^ORdescriptionLIKE{query}")
+        if priority:
+            sysparm_query_parts.append(f"priority={priority}")
+        if state:
+            sysparm_query_parts.append(f"state={state}")
+        if category:
+            sysparm_query_parts.append(f"category={category}")
+        if assignment_group:
+            sysparm_query_parts.append(f"assignment_group.nameLIKE{assignment_group}")
+        if correlation_id:
+            sysparm_query_parts.append(f"correlation_id={correlation_id}")
+
+        params = {
+            "sysparm_limit": limit,
+            "sysparm_query": "^".join(sysparm_query_parts) if sysparm_query_parts else ""
+        }
+
+        result = self._make_request("GET", "table/incident", params=params)
+        return result.get("result", [])
+
+    def get_incident(self, incident_number: str) -> Optional[Dict]:
+        params = {"sysparm_query": f"number={incident_number}"}
+        result = self._make_request("GET", "table/incident", params=params)
+        incidents = result.get("result", [])
+        return incidents[0] if incidents else None
+
+    def create_incident(self, data: Dict) -> Dict:
+        result = self._make_request("POST", "table/incident", data=data)
+        return result.get("result", {})
+
+    def update_incident(self, sys_id: str, data: Dict) -> Dict:
+        result = self._make_request("PATCH", f"table/incident/{sys_id}", data=data)
+        return result.get("result", {})
+
+
+def execute_tool_mock(name: str, arguments: Dict) -> Dict:
+    """Execute a tool using mock data"""
+
+    if name == "search_incidents":
+        results = MOCK_INCIDENTS.copy()
+
+        # Apply filters
+        if arguments.get("priority"):
+            results = [i for i in results if i["priority"] == arguments["priority"]]
+        if arguments.get("state"):
+            results = [i for i in results if i["state"] == arguments["state"]]
+        if arguments.get("category"):
+            results = [i for i in results if arguments["category"].lower() in i["category"].lower()]
+        if arguments.get("assignment_group"):
+            results = [i for i in results if arguments["assignment_group"].lower() in i["assignment_group"].lower()]
+        if arguments.get("query"):
+            query = arguments["query"].lower()
+            results = [i for i in results if query in i["short_description"].lower() or query in i["description"].lower()]
+
+        limit = arguments.get("limit", 10)
+        results = results[:limit]
+
+        # Enrich with readable values
+        for incident in results:
+            incident["state_display"] = STATE_MAP.get(incident["state"], incident["state"])
+            incident["priority_display"] = PRIORITY_MAP.get(incident["priority"], incident["priority"])
+
+        return {
+            "mode": "mock",
+            "count": len(results),
+            "incidents": results
+        }
+
+    elif name == "get_incident":
+        incident_number = arguments.get("incident_number", "")
+        for incident in MOCK_INCIDENTS:
+            if incident["number"] == incident_number:
+                incident["state_display"] = STATE_MAP.get(incident["state"], incident["state"])
+                incident["priority_display"] = PRIORITY_MAP.get(incident["priority"], incident["priority"])
+                return {"mode": "mock", "incident": incident}
+        return {"error": f"Incident {incident_number} not found"}
+
+    elif name == "create_incident":
+        new_number = f"INC{random.randint(1000000, 9999999)}"
+        new_incident = {
+            "number": new_number,
+            "short_description": arguments.get("short_description", ""),
+            "description": arguments.get("description", ""),
+            "priority": arguments.get("priority", "3"),
+            "state": "1",
+            "category": arguments.get("category", "Inquiry / Help"),
+            "assigned_to": "",
+            "assignment_group": arguments.get("assignment_group", ""),
+            "caller_id": arguments.get("caller_id", "System"),
+            "sys_created_on": datetime.now().isoformat(),
+            "sys_updated_on": datetime.now().isoformat(),
+            "work_notes": ""
+        }
+        MOCK_INCIDENTS.append(new_incident)
+        return {
+            "mode": "mock",
+            "message": f"Incident {new_number} created successfully",
+            "incident": new_incident
+        }
+
+    elif name == "update_incident":
+        incident_number = arguments.get("incident_number", "")
+        for incident in MOCK_INCIDENTS:
+            if incident["number"] == incident_number:
+                if arguments.get("state"):
+                    incident["state"] = arguments["state"]
+                if arguments.get("work_notes"):
+                    if incident["work_notes"]:
+                        incident["work_notes"] += f"\n\n{datetime.now().isoformat()}: {arguments['work_notes']}"
+                    else:
+                        incident["work_notes"] = f"{datetime.now().isoformat()}: {arguments['work_notes']}"
+                if arguments.get("assigned_to"):
+                    incident["assigned_to"] = arguments["assigned_to"]
+                incident["sys_updated_on"] = datetime.now().isoformat()
+                return {"mode": "mock", "message": f"Incident {incident_number} updated", "incident": incident}
+        return {"error": f"Incident {incident_number} not found"}
+
+    elif name == "get_related_cis":
+        incident_number = arguments.get("incident_number", "")
+        # Return mock CIs based on incident category
+        incident = None
+        for inc in MOCK_INCIDENTS:
+            if inc["number"] == incident_number:
+                incident = inc
+                break
+
+        if not incident:
+            return {"error": f"Incident {incident_number} not found"}
+
+        # Simple logic: return relevant CIs based on category
+        related_cis = []
+        category = incident.get("category", "").lower()
+        if "database" in category:
+            related_cis = [ci for ci in MOCK_CMDB_CIS if "database" in ci["sys_class_name"]]
+        elif "databricks" in category.lower() or "cloud" in category.lower():
+            related_cis = [ci for ci in MOCK_CMDB_CIS if "cloud" in ci["sys_class_name"] or "databricks" in ci["name"].lower()]
+        elif "data" in category.lower() or "etl" in category.lower():
+            related_cis = [ci for ci in MOCK_CMDB_CIS if "pipeline" in ci["name"].lower() or "databricks" in ci["name"].lower()]
+        else:
+            related_cis = MOCK_CMDB_CIS[:2]  # Return first two CIs
+
+        return {"mode": "mock", "incident": incident_number, "related_cis": related_cis}
+
+    elif name == "search_cmdb":
+        results = MOCK_CMDB_CIS.copy()
+
+        if arguments.get("query"):
+            query = arguments["query"].lower()
+            results = [ci for ci in results if query in ci["name"].lower() or query in ci.get("comments", "").lower()]
+        if arguments.get("ci_class"):
+            results = [ci for ci in results if arguments["ci_class"] in ci["sys_class_name"]]
+        if arguments.get("environment"):
+            results = [ci for ci in results if arguments["environment"].lower() == ci["environment"].lower()]
+
+        return {"mode": "mock", "count": len(results), "configuration_items": results}
+
+    elif name == "get_incident_metrics":
+        # Generate mock metrics
+        open_incidents = [i for i in MOCK_INCIDENTS if i["state"] in ["1", "2", "3"]]
+
+        metrics = {
+            "mode": "mock",
+            "time_range": arguments.get("time_range", "last_day"),
+            "total_incidents": len(MOCK_INCIDENTS),
+            "open_incidents": len(open_incidents),
+            "by_priority": {},
+            "by_state": {},
+            "by_category": {}
+        }
+
+        for incident in MOCK_INCIDENTS:
+            priority = PRIORITY_MAP.get(incident["priority"], "Unknown")
+            state = STATE_MAP.get(incident["state"], "Unknown")
+            category = incident.get("category", "Unknown")
+
+            metrics["by_priority"][priority] = metrics["by_priority"].get(priority, 0) + 1
+            metrics["by_state"][state] = metrics["by_state"].get(state, 0) + 1
+            metrics["by_category"][category] = metrics["by_category"].get(category, 0) + 1
+
+        return metrics
+
+    else:
+        return {"error": f"Unknown tool: {name}"}
+
+
+def execute_tool_real(name: str, arguments: Dict, client: ServiceNowClient) -> Dict:
+    """Execute a tool using real ServiceNow API"""
+
+    try:
+        if name == "search_incidents":
+            incidents = client.search_incidents(
+                query=arguments.get("query"),
+                priority=arguments.get("priority"),
+                state=arguments.get("state"),
+                category=arguments.get("category"),
+                assignment_group=arguments.get("assignment_group"),
+                correlation_id=arguments.get("correlation_id"),
+                limit=arguments.get("limit", 10)
+            )
+            return {"mode": "real", "count": len(incidents), "incidents": incidents}
+
+        elif name == "get_incident":
+            incident = client.get_incident(arguments["incident_number"])
+            if incident:
+                return {"mode": "real", "incident": incident}
+            return {"error": f"Incident {arguments['incident_number']} not found"}
+
+        elif name == "create_incident":
+            data = {
+                "short_description": arguments["short_description"],
+                "description": arguments.get("description", ""),
+                "priority": arguments.get("priority", "3"),
+                "category": arguments.get("category", ""),
+                "assignment_group": arguments.get("assignment_group", ""),
+                "caller_id": arguments.get("caller_id", "")
+            }
+            incident = client.create_incident(data)
+            return {"mode": "real", "message": "Incident created", "incident": incident}
+
+        elif name == "update_incident":
+            incident = client.get_incident(arguments["incident_number"])
+            if not incident:
+                return {"error": f"Incident {arguments['incident_number']} not found"}
+
+            data = {}
+            if arguments.get("state"):
+                data["state"] = arguments["state"]
+            if arguments.get("work_notes"):
+                data["work_notes"] = arguments["work_notes"]
+            if arguments.get("assigned_to"):
+                data["assigned_to"] = arguments["assigned_to"]
+
+            updated = client.update_incident(incident["sys_id"], data)
+            return {"mode": "real", "message": "Incident updated", "incident": updated}
+
+        else:
+            return execute_tool_mock(name, arguments)
+
+    except requests.exceptions.RequestException as e:
+        return {"error": f"ServiceNow API error: {str(e)}"}
+
+
+def handle_jsonrpc(data: Dict) -> Optional[Dict]:
+    """Handle a JSON-RPC request"""
+    method = data.get("method", "")
+    params = data.get("params", {})
+    req_id = data.get("id")
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "serverInfo": {
+                    "name": "servicenow-mcp-server",
+                    "version": "1.0.0"
+                },
+                "capabilities": {
+                    "tools": {"listChanged": False},
+                    "resources": {"listChanged": False},
+                    "prompts": {"listChanged": False}
+                }
+            }
+        }
+
+    elif method == "initialized":
+        return None
+
+    elif method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"tools": TOOLS}
+        }
+
+    elif method == "tools/call":
+        tool_name = params.get("name", "")
+        arguments = params.get("arguments", {})
+
+        if MOCK_MODE:
+            result = execute_tool_mock(tool_name, arguments)
+        else:
+            client = ServiceNowClient(
+                instance_url=INSTANCE_URL,
+                auth_method=AUTH_METHOD,
+                client_id=CLIENT_ID,
+                client_secret=CLIENT_SECRET,
+                pat=PAT,
+                username=USERNAME,
+                password=PASSWORD
+            )
+            result = execute_tool_real(tool_name, arguments, client)
+
+        if "error" in result:
+            content = [{"type": "text", "text": f"Error: {result['error']}"}]
+            is_error = True
+        else:
+            content = [{"type": "text", "text": json.dumps(result, indent=2, default=str)}]
+            is_error = False
+
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"content": content, "isError": is_error}
+        }
+
+    elif method == "resources/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"resources": []}
+        }
+
+    elif method == "prompts/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"prompts": []}
+        }
+
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Method not found: {method}"}
+        }
+
+
+@app.route('/mcp', methods=['POST', 'GET'])
+def mcp_endpoint():
+    """Main MCP endpoint"""
+    if request.method == 'GET':
+        return Response("SSE not implemented", status=501)
+
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No JSON data"}), 400
+
+        response = handle_jsonrpc(data)
+
+        if response is None:
+            return '', 200
+
+        resp = jsonify(response)
+        resp.headers['MCP-Protocol-Version'] = '2025-06-18'
+        return resp
+
+    except Exception as e:
+        return jsonify({
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32700, "message": str(e)}
+        }), 500
+
+
+@app.route('/health', methods=['GET'])
+def health():
+    return jsonify({
+        "status": "healthy",
+        "mode": "mock" if MOCK_MODE else "real",
+        "instance_url": INSTANCE_URL if not MOCK_MODE else "N/A (mock mode)",
+        "auth_method": AUTH_METHOD if not MOCK_MODE else "N/A (mock mode)"
+    })
+
+
+if __name__ == '__main__':
+    print("=" * 70)
+    print("  ServiceNow MCP Server")
+    print("=" * 70)
+    print()
+    print(f"  Mode: {'MOCK (demo data)' if MOCK_MODE else 'REAL (ServiceNow API)'}")
+    if not MOCK_MODE:
+        print(f"  Instance: {INSTANCE_URL}")
+        print(f"  Auth Method: {AUTH_METHOD}")
+    print()
+    print("  Available tools:")
+    for tool in TOOLS:
+        print(f"    - {tool['name']}: {tool['description'][:60]}...")
+    print()
+    print(f"  Server running at: http://{HOST}:{PORT}/mcp")
+    print()
+    print("  Environment variables:")
+    print("    SERVICENOW_MOCK_MODE=true|false (default: true)")
+    print("    SERVICENOW_INSTANCE_URL=https://your-instance.service-now.com")
+    print("    SERVICENOW_AUTH_METHOD=oauth|pat|basic (default: oauth)")
+    print()
+    print("    # OAuth 2.0 (recommended):")
+    print("    SERVICENOW_CLIENT_ID=your_client_id")
+    print("    SERVICENOW_CLIENT_SECRET=your_client_secret")
+    print()
+    print("    # Personal Access Token:")
+    print("    SERVICENOW_PAT=your_personal_access_token")
+    print()
+    print("    # Basic Auth (legacy):")
+    print("    SERVICENOW_USERNAME=your_username")
+    print("    SERVICENOW_PASSWORD=your_password")
+    print()
+    print("  Press Ctrl+C to stop")
+    print()
+
+    app.run(host=HOST, port=PORT, debug=False)

--- a/examples/servicenow-databricks-demo/unified-mcp-endpoint.patch
+++ b/examples/servicenow-databricks-demo/unified-mcp-endpoint.patch
@@ -1,0 +1,793 @@
+From af4864abef172c8c710f123fc0d630bfdbb34712 Mon Sep 17 00:00:00 2001
+From: Dave Stanley <dstanleyd@gmail.com>
+Date: Sun, 22 Feb 2026 10:27:34 -0500
+Subject: [PATCH] Add unified MCP endpoint for aggregated adapter access. Adds
+ /api/v1/mcp endpoint that aggregates tools, resources, and prompts from all
+ registered adapters into a single MCP interface. Tool names prefixed with
+ adapter name (e.g., mytoolname__get_incident) and calls are routed to the
+ correct backend adapter.
+
+---
+ cmd/uniproxy/main.go             |   8 +
+ internal/handlers/unified_mcp.go | 744 +++++++++++++++++++++++++++++++
+ 2 files changed, 752 insertions(+)
+ create mode 100644 internal/handlers/unified_mcp.go
+
+diff --git a/cmd/uniproxy/main.go b/cmd/uniproxy/main.go
+index 0b88060..fa728eb 100644
+--- a/cmd/uniproxy/main.go
++++ b/cmd/uniproxy/main.go
+@@ -635,6 +635,10 @@ func RunUniproxy() {
+    logging.ProxyLogger.Info("AdapterHandler created: %v", adapterHandler != nil)
+    logging.ProxyLogger.Success("AdapterService and AdapterHandler initialized")
+
++   // Initialize UnifiedMCPHandler for aggregated MCP endpoint
++   unifiedMCPHandler := handlers.NewUnifiedMCPHandler(adapterService, userGroupService)
++   logging.ProxyLogger.Info("UnifiedMCPHandler created: %v", unifiedMCPHandler != nil)
++
+    // Adapter handlers are now used directly in Gin routes
+
+    // Helper function to convert Gin context to standard HTTP handler
+@@ -798,6 +802,10 @@ func RunUniproxy() {
+            })
+        }
+
++       // Unified MCP endpoint - aggregates all adapters into a single MCP interface
++       logging.ProxyLogger.Info("Setting up unified MCP endpoint")
++       v1.Any("/mcp", ginToHTTPHandler(unifiedMCPHandler.HandleUnifiedMCP))
++
+        // Registry routes
+        registry := v1.Group("/registry")
+        {
+diff --git a/internal/handlers/unified_mcp.go b/internal/handlers/unified_mcp.go
+new file mode 100644
+index 0000000..085bf03
+--- /dev/null
++++ b/internal/handlers/unified_mcp.go
+@@ -0,0 +1,744 @@
++package handlers
++
++import (
++   "bytes"
++   "context"
++   "encoding/json"
++   "fmt"
++   "io"
++   "net/http"
++   "strings"
++   "sync"
++   "time"
++
++   "suse-ai-up/pkg/logging"
++   "suse-ai-up/pkg/models"
++   "suse-ai-up/pkg/services"
++   adaptersvc "suse-ai-up/pkg/services/adapters"
++)
++
++// UnifiedMCPHandler handles unified MCP protocol requests that aggregate
++// tools, resources, and prompts from all registered adapters
++type UnifiedMCPHandler struct {
++   adapterService   *adaptersvc.AdapterService
++   userGroupService *services.UserGroupService
++   httpClient       *http.Client
++}
++
++// NewUnifiedMCPHandler creates a new unified MCP handler
++func NewUnifiedMCPHandler(adapterService *adaptersvc.AdapterService, userGroupService *services.UserGroupService) *UnifiedMCPHandler {
++   return &UnifiedMCPHandler{
++       adapterService:   adapterService,
++       userGroupService: userGroupService,
++       httpClient: &http.Client{
++           Timeout: 120 * time.Second, // Increased for slow SQL queries
++       },
++   }
++}
++
++// MCPRequest represents an incoming MCP JSON-RPC request
++type MCPRequest struct {
++   JSONRPC string      `json:"jsonrpc"`
++   ID      interface{} `json:"id"`
++   Method  string      `json:"method"`
++   Params  interface{} `json:"params,omitempty"`
++}
++
++// MCPResponse represents an MCP JSON-RPC response
++type MCPResponse struct {
++   JSONRPC string        `json:"jsonrpc"`
++   ID      interface{}   `json:"id,omitempty"`
++   Result  interface{}   `json:"result,omitempty"`
++   Error   *MCPRPCError  `json:"error,omitempty"`
++}
++
++// MCPRPCError represents a JSON-RPC error
++type MCPRPCError struct {
++   Code    int         `json:"code"`
++   Message string      `json:"message"`
++   Data    interface{} `json:"data,omitempty"`
++}
++
++// Tool represents an MCP tool
++type Tool struct {
++   Name        string      `json:"name"`
++   Description string      `json:"description,omitempty"`
++   InputSchema interface{} `json:"inputSchema,omitempty"`
++}
++
++// Resource represents an MCP resource
++type Resource struct {
++   URI         string `json:"uri"`
++   Name        string `json:"name,omitempty"`
++   Description string `json:"description,omitempty"`
++   MimeType    string `json:"mimeType,omitempty"`
++}
++
++// Prompt represents an MCP prompt
++type Prompt struct {
++   Name        string        `json:"name"`
++   Description string        `json:"description,omitempty"`
++   Arguments   []interface{} `json:"arguments,omitempty"`
++}
++
++// ToolsListResult represents the result of tools/list
++type ToolsListResult struct {
++   Tools []Tool `json:"tools"`
++}
++
++// ResourcesListResult represents the result of resources/list
++type ResourcesListResult struct {
++   Resources []Resource `json:"resources"`
++}
++
++// PromptsListResult represents the result of prompts/list
++type PromptsListResult struct {
++   Prompts []Prompt `json:"prompts"`
++}
++
++// ToolCallParams represents parameters for tools/call
++type ToolCallParams struct {
++   Name      string                 `json:"name"`
++   Arguments map[string]interface{} `json:"arguments,omitempty"`
++}
++
++// HandleUnifiedMCP handles the unified MCP endpoint
++// @Summary Unified MCP endpoint
++// @Description Aggregates tools, resources, and prompts from all adapters
++// @Tags mcp
++// @Accept json
++// @Produce json
++// @Param X-User-ID header string false "User ID" default(default-user)
++// @Success 200 {object} MCPResponse "MCP response"
++// @Failure 400 {object} ErrorResponse "Invalid request"
++// @Failure 500 {object} ErrorResponse "Internal server error"
++// @Router /api/v1/mcp [post]
++func (h *UnifiedMCPHandler) HandleUnifiedMCP(w http.ResponseWriter, r *http.Request) {
++   if r.Method != http.MethodPost {
++       h.sendError(w, nil, -32600, "Only POST method is supported")
++       return
++   }
++
++   // Parse the incoming request
++   body, err := io.ReadAll(r.Body)
++   if err != nil {
++       h.sendError(w, nil, -32700, "Failed to read request body")
++       return
++   }
++   defer r.Body.Close()
++
++   var req MCPRequest
++   if err := json.Unmarshal(body, &req); err != nil {
++       h.sendError(w, nil, -32700, "Invalid JSON: "+err.Error())
++       return
++   }
++
++   // Get user ID from header
++   userID := r.Header.Get("X-User-ID")
++   if userID == "" {
++       userID = "default-user"
++   }
++
++   logging.ProxyLogger.Info("UnifiedMCP: Handling method %s for user %s", req.Method, userID)
++
++   var response *MCPResponse
++
++   switch req.Method {
++   case "initialize":
++       response = h.handleInitialize(r.Context(), &req)
++   case "initialized":
++       // No response needed for initialized notification
++       w.WriteHeader(http.StatusOK)
++       return
++   case "tools/list":
++       response = h.handleToolsList(r.Context(), &req, userID)
++   case "tools/call":
++       response = h.handleToolsCall(r.Context(), &req, userID, r.Header)
++   case "resources/list":
++       response = h.handleResourcesList(r.Context(), &req, userID)
++   case "resources/read":
++       response = h.handleResourcesRead(r.Context(), &req, userID, r.Header)
++   case "prompts/list":
++       response = h.handlePromptsList(r.Context(), &req, userID)
++   case "prompts/get":
++       response = h.handlePromptsGet(r.Context(), &req, userID, r.Header)
++   default:
++       response = &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32601, Message: fmt.Sprintf("Method not found: %s", req.Method)},
++       }
++   }
++
++   w.Header().Set("Content-Type", "application/json")
++   w.Header().Set("MCP-Protocol-Version", "2025-06-18")
++   json.NewEncoder(w).Encode(response)
++}
++
++// handleInitialize handles the initialize method
++func (h *UnifiedMCPHandler) handleInitialize(ctx context.Context, req *MCPRequest) *MCPResponse {
++   return &MCPResponse{
++       JSONRPC: "2.0",
++       ID:      req.ID,
++       Result: map[string]interface{}{
++           "protocolVersion": "2025-06-18",
++           "serverInfo": map[string]interface{}{
++               "name":    "suse-ai-unified-proxy",
++               "version": "1.0.0",
++           },
++           "capabilities": map[string]interface{}{
++               "tools":     map[string]interface{}{"listChanged": false},
++               "resources": map[string]interface{}{"listChanged": false},
++               "prompts":   map[string]interface{}{"listChanged": false},
++           },
++       },
++   }
++}
++
++// handleToolsList aggregates tools from all adapters
++func (h *UnifiedMCPHandler) handleToolsList(ctx context.Context, req *MCPRequest, userID string) *MCPResponse {
++   adapters, err := h.adapterService.ListAdapters(ctx, userID, h.userGroupService)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Failed to list adapters: " + err.Error()},
++       }
++   }
++
++   var allTools []Tool
++   var mu sync.Mutex
++   var wg sync.WaitGroup
++
++   for _, adapter := range adapters {
++       if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
++           continue
++       }
++
++       wg.Add(1)
++       go func(adapter models.AdapterResource) {
++           defer wg.Done()
++
++           tools, err := h.fetchToolsFromAdapter(ctx, adapter)
++           if err != nil {
++               logging.ProxyLogger.Warn("UnifiedMCP: Failed to fetch tools from %s: %v", adapter.Name, err)
++               return
++           }
++
++           // Prefix tool names with adapter name
++           mu.Lock()
++           for _, tool := range tools {
++               prefixedTool := Tool{
++                   Name:        adapter.Name + "__" + tool.Name,
++                   Description: fmt.Sprintf("[%s] %s", adapter.Name, tool.Description),
++                   InputSchema: tool.InputSchema,
++               }
++               allTools = append(allTools, prefixedTool)
++           }
++           mu.Unlock()
++       }(adapter)
++   }
++
++   wg.Wait()
++
++   return &MCPResponse{
++       JSONRPC: "2.0",
++       ID:      req.ID,
++       Result:  ToolsListResult{Tools: allTools},
++   }
++}
++
++// handleToolsCall routes a tool call to the appropriate adapter
++func (h *UnifiedMCPHandler) handleToolsCall(ctx context.Context, req *MCPRequest, userID string, headers http.Header) *MCPResponse {
++   // Parse params
++   paramsJSON, err := json.Marshal(req.Params)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Invalid params"},
++       }
++   }
++
++   var params ToolCallParams
++   if err := json.Unmarshal(paramsJSON, &params); err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Invalid params: " + err.Error()},
++       }
++   }
++
++   // Extract adapter prefix from tool name (format: adapter__toolname)
++   parts := strings.SplitN(params.Name, "__", 2)
++   if len(parts) != 2 {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Tool name must be prefixed with adapter name (e.g., servicenow__get_incident)"},
++       }
++   }
++
++   adapterName := parts[0]
++   toolName := parts[1]
++
++   // Get the adapter
++   adapter, err := h.adapterService.GetAdapter(ctx, userID, adapterName, h.userGroupService)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Adapter not found: " + adapterName},
++       }
++   }
++
++   if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Adapter does not support remote MCP"},
++       }
++   }
++
++   // Forward the request with unprefixed tool name
++   unprefixedReq := MCPRequest{
++       JSONRPC: "2.0",
++       ID:      req.ID,
++       Method:  "tools/call",
++       Params: map[string]interface{}{
++           "name":      toolName,
++           "arguments": params.Arguments,
++       },
++   }
++
++   return h.forwardToAdapter(ctx, adapter, &unprefixedReq, headers)
++}
++
++// handleResourcesList aggregates resources from all adapters
++func (h *UnifiedMCPHandler) handleResourcesList(ctx context.Context, req *MCPRequest, userID string) *MCPResponse {
++   adapters, err := h.adapterService.ListAdapters(ctx, userID, h.userGroupService)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Failed to list adapters: " + err.Error()},
++       }
++   }
++
++   var allResources []Resource
++   var mu sync.Mutex
++   var wg sync.WaitGroup
++
++   for _, adapter := range adapters {
++       if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
++           continue
++       }
++
++       wg.Add(1)
++       go func(adapter models.AdapterResource) {
++           defer wg.Done()
++
++           resources, err := h.fetchResourcesFromAdapter(ctx, adapter)
++           if err != nil {
++               logging.ProxyLogger.Warn("UnifiedMCP: Failed to fetch resources from %s: %v", adapter.Name, err)
++               return
++           }
++
++           // Prefix resource URIs with adapter name
++           mu.Lock()
++           for _, resource := range resources {
++               prefixedResource := Resource{
++                   URI:         adapter.Name + "://" + resource.URI,
++                   Name:        fmt.Sprintf("[%s] %s", adapter.Name, resource.Name),
++                   Description: resource.Description,
++                   MimeType:    resource.MimeType,
++               }
++               allResources = append(allResources, prefixedResource)
++           }
++           mu.Unlock()
++       }(adapter)
++   }
++
++   wg.Wait()
++
++   return &MCPResponse{
++       JSONRPC: "2.0",
++       ID:      req.ID,
++       Result:  ResourcesListResult{Resources: allResources},
++   }
++}
++
++// handleResourcesRead routes a resource read to the appropriate adapter
++func (h *UnifiedMCPHandler) handleResourcesRead(ctx context.Context, req *MCPRequest, userID string, headers http.Header) *MCPResponse {
++   // Parse params to get URI
++   paramsJSON, err := json.Marshal(req.Params)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Invalid params"},
++       }
++   }
++
++   var params struct {
++       URI string `json:"uri"`
++   }
++   if err := json.Unmarshal(paramsJSON, &params); err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Invalid params: " + err.Error()},
++       }
++   }
++
++   // Extract adapter prefix from URI (format: adapter://original_uri)
++   parts := strings.SplitN(params.URI, "://", 2)
++   if len(parts) != 2 {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Resource URI must be prefixed with adapter name"},
++       }
++   }
++
++   adapterName := parts[0]
++   originalURI := parts[1]
++
++   // Get the adapter
++   adapter, err := h.adapterService.GetAdapter(ctx, userID, adapterName, h.userGroupService)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Adapter not found: " + adapterName},
++       }
++   }
++
++   // Forward the request with unprefixed URI
++   unprefixedReq := MCPRequest{
++       JSONRPC: "2.0",
++       ID:      req.ID,
++       Method:  "resources/read",
++       Params:  map[string]interface{}{"uri": originalURI},
++   }
++
++   return h.forwardToAdapter(ctx, adapter, &unprefixedReq, headers)
++}
++
++// handlePromptsList aggregates prompts from all adapters
++func (h *UnifiedMCPHandler) handlePromptsList(ctx context.Context, req *MCPRequest, userID string) *MCPResponse {
++   adapters, err := h.adapterService.ListAdapters(ctx, userID, h.userGroupService)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Failed to list adapters: " + err.Error()},
++       }
++   }
++
++   var allPrompts []Prompt
++   var mu sync.Mutex
++   var wg sync.WaitGroup
++
++   for _, adapter := range adapters {
++       if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
++           continue
++       }
++
++       wg.Add(1)
++       go func(adapter models.AdapterResource) {
++           defer wg.Done()
++
++           prompts, err := h.fetchPromptsFromAdapter(ctx, adapter)
++           if err != nil {
++               logging.ProxyLogger.Warn("UnifiedMCP: Failed to fetch prompts from %s: %v", adapter.Name, err)
++               return
++           }
++
++           // Prefix prompt names with adapter name
++           mu.Lock()
++           for _, prompt := range prompts {
++               prefixedPrompt := Prompt{
++                   Name:        adapter.Name + "__" + prompt.Name,
++                   Description: fmt.Sprintf("[%s] %s", adapter.Name, prompt.Description),
++                   Arguments:   prompt.Arguments,
++               }
++               allPrompts = append(allPrompts, prefixedPrompt)
++           }
++           mu.Unlock()
++       }(adapter)
++   }
++
++   wg.Wait()
++
++   return &MCPResponse{
++       JSONRPC: "2.0",
++       ID:      req.ID,
++       Result:  PromptsListResult{Prompts: allPrompts},
++   }
++}
++
++// handlePromptsGet routes a prompt get to the appropriate adapter
++func (h *UnifiedMCPHandler) handlePromptsGet(ctx context.Context, req *MCPRequest, userID string, headers http.Header) *MCPResponse {
++   // Parse params to get prompt name
++   paramsJSON, err := json.Marshal(req.Params)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Invalid params"},
++       }
++   }
++
++   var params struct {
++       Name      string                 `json:"name"`
++       Arguments map[string]interface{} `json:"arguments,omitempty"`
++   }
++   if err := json.Unmarshal(paramsJSON, &params); err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Invalid params: " + err.Error()},
++       }
++   }
++
++   // Extract adapter prefix from prompt name (format: adapter__promptname)
++   parts := strings.SplitN(params.Name, "__", 2)
++   if len(parts) != 2 {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Prompt name must be prefixed with adapter name"},
++       }
++   }
++
++   adapterName := parts[0]
++   promptName := parts[1]
++
++   // Get the adapter
++   adapter, err := h.adapterService.GetAdapter(ctx, userID, adapterName, h.userGroupService)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Adapter not found: " + adapterName},
++       }
++   }
++
++   // Forward the request with unprefixed prompt name
++   unprefixedReq := MCPRequest{
++       JSONRPC: "2.0",
++       ID:      req.ID,
++       Method:  "prompts/get",
++       Params: map[string]interface{}{
++           "name":      promptName,
++           "arguments": params.Arguments,
++       },
++   }
++
++   return h.forwardToAdapter(ctx, adapter, &unprefixedReq, headers)
++}
++
++// fetchToolsFromAdapter fetches tools from a single adapter
++func (h *UnifiedMCPHandler) fetchToolsFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Tool, error) {
++   req := MCPRequest{
++       JSONRPC: "2.0",
++       ID:      1,
++       Method:  "tools/list",
++       Params:  map[string]interface{}{},
++   }
++
++   resp, err := h.makeAdapterRequest(ctx, adapter.RemoteUrl, &req)
++   if err != nil {
++       return nil, err
++   }
++
++   if resp.Error != nil {
++       return nil, fmt.Errorf("adapter error: %s", resp.Error.Message)
++   }
++
++   // Parse result
++   resultJSON, err := json.Marshal(resp.Result)
++   if err != nil {
++       return nil, err
++   }
++
++   var result ToolsListResult
++   if err := json.Unmarshal(resultJSON, &result); err != nil {
++       return nil, err
++   }
++
++   return result.Tools, nil
++}
++
++// fetchResourcesFromAdapter fetches resources from a single adapter
++func (h *UnifiedMCPHandler) fetchResourcesFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Resource, error) {
++   req := MCPRequest{
++       JSONRPC: "2.0",
++       ID:      1,
++       Method:  "resources/list",
++       Params:  map[string]interface{}{},
++   }
++
++   resp, err := h.makeAdapterRequest(ctx, adapter.RemoteUrl, &req)
++   if err != nil {
++       return nil, err
++   }
++
++   if resp.Error != nil {
++       return nil, fmt.Errorf("adapter error: %s", resp.Error.Message)
++   }
++
++   // Parse result
++   resultJSON, err := json.Marshal(resp.Result)
++   if err != nil {
++       return nil, err
++   }
++
++   var result ResourcesListResult
++   if err := json.Unmarshal(resultJSON, &result); err != nil {
++       return nil, err
++   }
++
++   return result.Resources, nil
++}
++
++// fetchPromptsFromAdapter fetches prompts from a single adapter
++func (h *UnifiedMCPHandler) fetchPromptsFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Prompt, error) {
++   req := MCPRequest{
++       JSONRPC: "2.0",
++       ID:      1,
++       Method:  "prompts/list",
++       Params:  map[string]interface{}{},
++   }
++
++   resp, err := h.makeAdapterRequest(ctx, adapter.RemoteUrl, &req)
++   if err != nil {
++       return nil, err
++   }
++
++   if resp.Error != nil {
++       return nil, fmt.Errorf("adapter error: %s", resp.Error.Message)
++   }
++
++   // Parse result
++   resultJSON, err := json.Marshal(resp.Result)
++   if err != nil {
++       return nil, err
++   }
++
++   var result PromptsListResult
++   if err := json.Unmarshal(resultJSON, &result); err != nil {
++       return nil, err
++   }
++
++   return result.Prompts, nil
++}
++
++// makeAdapterRequest makes an HTTP request to an adapter
++func (h *UnifiedMCPHandler) makeAdapterRequest(ctx context.Context, url string, req *MCPRequest) (*MCPResponse, error) {
++   body, err := json.Marshal(req)
++   if err != nil {
++       return nil, err
++   }
++
++   httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
++   if err != nil {
++       return nil, err
++   }
++
++   httpReq.Header.Set("Content-Type", "application/json")
++
++   resp, err := h.httpClient.Do(httpReq)
++   if err != nil {
++       return nil, err
++   }
++   defer resp.Body.Close()
++
++   respBody, err := io.ReadAll(resp.Body)
++   if err != nil {
++       return nil, err
++   }
++
++   var mcpResp MCPResponse
++   if err := json.Unmarshal(respBody, &mcpResp); err != nil {
++       return nil, err
++   }
++
++   return &mcpResp, nil
++}
++
++// forwardToAdapter forwards a request to a specific adapter
++func (h *UnifiedMCPHandler) forwardToAdapter(ctx context.Context, adapter *models.AdapterResource, req *MCPRequest, headers http.Header) *MCPResponse {
++   if adapter.RemoteUrl == "" {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32602, Message: "Adapter has no remote URL"},
++       }
++   }
++
++   body, err := json.Marshal(req)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Failed to marshal request"},
++       }
++   }
++
++   httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, adapter.RemoteUrl, bytes.NewReader(body))
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Failed to create request"},
++       }
++   }
++
++   httpReq.Header.Set("Content-Type", "application/json")
++   // Forward relevant headers
++   if userID := headers.Get("X-User-ID"); userID != "" {
++       httpReq.Header.Set("X-User-ID", userID)
++   }
++
++   resp, err := h.httpClient.Do(httpReq)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Failed to contact adapter: " + err.Error()},
++       }
++   }
++   defer resp.Body.Close()
++
++   respBody, err := io.ReadAll(resp.Body)
++   if err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Failed to read response"},
++       }
++   }
++
++   var mcpResp MCPResponse
++   if err := json.Unmarshal(respBody, &mcpResp); err != nil {
++       return &MCPResponse{
++           JSONRPC: "2.0",
++           ID:      req.ID,
++           Error:   &MCPRPCError{Code: -32603, Message: "Invalid response from adapter"},
++       }
++   }
++
++   return &mcpResp
++}
++
++// sendError sends an error response
++func (h *UnifiedMCPHandler) sendError(w http.ResponseWriter, id interface{}, code int, message string) {
++   w.Header().Set("Content-Type", "application/json")
++   json.NewEncoder(w).Encode(MCPResponse{
++       JSONRPC: "2.0",
++       ID:      id,
++       Error:   &MCPRPCError{Code: code, Message: message},
++   })
++}
+--
+2.50.1 (Apple Git-155)

--- a/internal/handlers/unified_mcp.go
+++ b/internal/handlers/unified_mcp.go
@@ -1,0 +1,744 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"suse-ai-up/pkg/logging"
+	"suse-ai-up/pkg/models"
+	"suse-ai-up/pkg/services"
+	adaptersvc "suse-ai-up/pkg/services/adapters"
+)
+
+// UnifiedMCPHandler handles unified MCP protocol requests that aggregate
+// tools, resources, and prompts from all registered adapters
+type UnifiedMCPHandler struct {
+	adapterService   *adaptersvc.AdapterService
+	userGroupService *services.UserGroupService
+	httpClient       *http.Client
+}
+
+// NewUnifiedMCPHandler creates a new unified MCP handler
+func NewUnifiedMCPHandler(adapterService *adaptersvc.AdapterService, userGroupService *services.UserGroupService) *UnifiedMCPHandler {
+	return &UnifiedMCPHandler{
+		adapterService:   adapterService,
+		userGroupService: userGroupService,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second, // Increased for slow SQL queries
+		},
+	}
+}
+
+// MCPRequest represents an incoming MCP JSON-RPC request
+type MCPRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+// MCPResponse represents an MCP JSON-RPC response
+type MCPResponse struct {
+	JSONRPC string        `json:"jsonrpc"`
+	ID      interface{}   `json:"id,omitempty"`
+	Result  interface{}   `json:"result,omitempty"`
+	Error   *MCPRPCError  `json:"error,omitempty"`
+}
+
+// MCPRPCError represents a JSON-RPC error
+type MCPRPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// Tool represents an MCP tool
+type Tool struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	InputSchema interface{} `json:"inputSchema,omitempty"`
+}
+
+// Resource represents an MCP resource
+type Resource struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+// Prompt represents an MCP prompt
+type Prompt struct {
+	Name        string        `json:"name"`
+	Description string        `json:"description,omitempty"`
+	Arguments   []interface{} `json:"arguments,omitempty"`
+}
+
+// ToolsListResult represents the result of tools/list
+type ToolsListResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+// ResourcesListResult represents the result of resources/list
+type ResourcesListResult struct {
+	Resources []Resource `json:"resources"`
+}
+
+// PromptsListResult represents the result of prompts/list
+type PromptsListResult struct {
+	Prompts []Prompt `json:"prompts"`
+}
+
+// ToolCallParams represents parameters for tools/call
+type ToolCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+// HandleUnifiedMCP handles the unified MCP endpoint
+// @Summary Unified MCP endpoint
+// @Description Aggregates tools, resources, and prompts from all adapters
+// @Tags mcp
+// @Accept json
+// @Produce json
+// @Param X-User-ID header string false "User ID" default(default-user)
+// @Success 200 {object} MCPResponse "MCP response"
+// @Failure 400 {object} ErrorResponse "Invalid request"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Router /api/v1/mcp [post]
+func (h *UnifiedMCPHandler) HandleUnifiedMCP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.sendError(w, nil, -32600, "Only POST method is supported")
+		return
+	}
+
+	// Parse the incoming request
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.sendError(w, nil, -32700, "Failed to read request body")
+		return
+	}
+	defer r.Body.Close()
+
+	var req MCPRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		h.sendError(w, nil, -32700, "Invalid JSON: "+err.Error())
+		return
+	}
+
+	// Get user ID from header
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		userID = "default-user"
+	}
+
+	logging.ProxyLogger.Info("UnifiedMCP: Handling method %s for user %s", req.Method, userID)
+
+	var response *MCPResponse
+
+	switch req.Method {
+	case "initialize":
+		response = h.handleInitialize(r.Context(), &req)
+	case "initialized":
+		// No response needed for initialized notification
+		w.WriteHeader(http.StatusOK)
+		return
+	case "tools/list":
+		response = h.handleToolsList(r.Context(), &req, userID)
+	case "tools/call":
+		response = h.handleToolsCall(r.Context(), &req, userID, r.Header)
+	case "resources/list":
+		response = h.handleResourcesList(r.Context(), &req, userID)
+	case "resources/read":
+		response = h.handleResourcesRead(r.Context(), &req, userID, r.Header)
+	case "prompts/list":
+		response = h.handlePromptsList(r.Context(), &req, userID)
+	case "prompts/get":
+		response = h.handlePromptsGet(r.Context(), &req, userID, r.Header)
+	default:
+		response = &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32601, Message: fmt.Sprintf("Method not found: %s", req.Method)},
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("MCP-Protocol-Version", "2025-06-18")
+	json.NewEncoder(w).Encode(response)
+}
+
+// handleInitialize handles the initialize method
+func (h *UnifiedMCPHandler) handleInitialize(ctx context.Context, req *MCPRequest) *MCPResponse {
+	return &MCPResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]interface{}{
+			"protocolVersion": "2025-06-18",
+			"serverInfo": map[string]interface{}{
+				"name":    "suse-ai-unified-proxy",
+				"version": "1.0.0",
+			},
+			"capabilities": map[string]interface{}{
+				"tools":     map[string]interface{}{"listChanged": false},
+				"resources": map[string]interface{}{"listChanged": false},
+				"prompts":   map[string]interface{}{"listChanged": false},
+			},
+		},
+	}
+}
+
+// handleToolsList aggregates tools from all adapters
+func (h *UnifiedMCPHandler) handleToolsList(ctx context.Context, req *MCPRequest, userID string) *MCPResponse {
+	adapters, err := h.adapterService.ListAdapters(ctx, userID, h.userGroupService)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Failed to list adapters: " + err.Error()},
+		}
+	}
+
+	var allTools []Tool
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, adapter := range adapters {
+		if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
+			continue
+		}
+
+		wg.Add(1)
+		go func(adapter models.AdapterResource) {
+			defer wg.Done()
+
+			tools, err := h.fetchToolsFromAdapter(ctx, adapter)
+			if err != nil {
+				logging.ProxyLogger.Warn("UnifiedMCP: Failed to fetch tools from %s: %v", adapter.Name, err)
+				return
+			}
+
+			// Prefix tool names with adapter name
+			mu.Lock()
+			for _, tool := range tools {
+				prefixedTool := Tool{
+					Name:        adapter.Name + "__" + tool.Name,
+					Description: fmt.Sprintf("[%s] %s", adapter.Name, tool.Description),
+					InputSchema: tool.InputSchema,
+				}
+				allTools = append(allTools, prefixedTool)
+			}
+			mu.Unlock()
+		}(adapter)
+	}
+
+	wg.Wait()
+
+	return &MCPResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  ToolsListResult{Tools: allTools},
+	}
+}
+
+// handleToolsCall routes a tool call to the appropriate adapter
+func (h *UnifiedMCPHandler) handleToolsCall(ctx context.Context, req *MCPRequest, userID string, headers http.Header) *MCPResponse {
+	// Parse params
+	paramsJSON, err := json.Marshal(req.Params)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Invalid params"},
+		}
+	}
+
+	var params ToolCallParams
+	if err := json.Unmarshal(paramsJSON, &params); err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Invalid params: " + err.Error()},
+		}
+	}
+
+	// Extract adapter prefix from tool name (format: adapter__toolname)
+	parts := strings.SplitN(params.Name, "__", 2)
+	if len(parts) != 2 {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Tool name must be prefixed with adapter name (e.g., servicenow__get_incident)"},
+		}
+	}
+
+	adapterName := parts[0]
+	toolName := parts[1]
+
+	// Get the adapter
+	adapter, err := h.adapterService.GetAdapter(ctx, userID, adapterName, h.userGroupService)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Adapter not found: " + adapterName},
+		}
+	}
+
+	if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Adapter does not support remote MCP"},
+		}
+	}
+
+	// Forward the request with unprefixed tool name
+	unprefixedReq := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Method:  "tools/call",
+		Params: map[string]interface{}{
+			"name":      toolName,
+			"arguments": params.Arguments,
+		},
+	}
+
+	return h.forwardToAdapter(ctx, adapter, &unprefixedReq, headers)
+}
+
+// handleResourcesList aggregates resources from all adapters
+func (h *UnifiedMCPHandler) handleResourcesList(ctx context.Context, req *MCPRequest, userID string) *MCPResponse {
+	adapters, err := h.adapterService.ListAdapters(ctx, userID, h.userGroupService)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Failed to list adapters: " + err.Error()},
+		}
+	}
+
+	var allResources []Resource
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, adapter := range adapters {
+		if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
+			continue
+		}
+
+		wg.Add(1)
+		go func(adapter models.AdapterResource) {
+			defer wg.Done()
+
+			resources, err := h.fetchResourcesFromAdapter(ctx, adapter)
+			if err != nil {
+				logging.ProxyLogger.Warn("UnifiedMCP: Failed to fetch resources from %s: %v", adapter.Name, err)
+				return
+			}
+
+			// Prefix resource URIs with adapter name
+			mu.Lock()
+			for _, resource := range resources {
+				prefixedResource := Resource{
+					URI:         adapter.Name + "://" + resource.URI,
+					Name:        fmt.Sprintf("[%s] %s", adapter.Name, resource.Name),
+					Description: resource.Description,
+					MimeType:    resource.MimeType,
+				}
+				allResources = append(allResources, prefixedResource)
+			}
+			mu.Unlock()
+		}(adapter)
+	}
+
+	wg.Wait()
+
+	return &MCPResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  ResourcesListResult{Resources: allResources},
+	}
+}
+
+// handleResourcesRead routes a resource read to the appropriate adapter
+func (h *UnifiedMCPHandler) handleResourcesRead(ctx context.Context, req *MCPRequest, userID string, headers http.Header) *MCPResponse {
+	// Parse params to get URI
+	paramsJSON, err := json.Marshal(req.Params)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Invalid params"},
+		}
+	}
+
+	var params struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(paramsJSON, &params); err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Invalid params: " + err.Error()},
+		}
+	}
+
+	// Extract adapter prefix from URI (format: adapter://original_uri)
+	parts := strings.SplitN(params.URI, "://", 2)
+	if len(parts) != 2 {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Resource URI must be prefixed with adapter name"},
+		}
+	}
+
+	adapterName := parts[0]
+	originalURI := parts[1]
+
+	// Get the adapter
+	adapter, err := h.adapterService.GetAdapter(ctx, userID, adapterName, h.userGroupService)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Adapter not found: " + adapterName},
+		}
+	}
+
+	// Forward the request with unprefixed URI
+	unprefixedReq := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Method:  "resources/read",
+		Params:  map[string]interface{}{"uri": originalURI},
+	}
+
+	return h.forwardToAdapter(ctx, adapter, &unprefixedReq, headers)
+}
+
+// handlePromptsList aggregates prompts from all adapters
+func (h *UnifiedMCPHandler) handlePromptsList(ctx context.Context, req *MCPRequest, userID string) *MCPResponse {
+	adapters, err := h.adapterService.ListAdapters(ctx, userID, h.userGroupService)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Failed to list adapters: " + err.Error()},
+		}
+	}
+
+	var allPrompts []Prompt
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, adapter := range adapters {
+		if adapter.ConnectionType != models.ConnectionTypeRemoteHttp || adapter.RemoteUrl == "" {
+			continue
+		}
+
+		wg.Add(1)
+		go func(adapter models.AdapterResource) {
+			defer wg.Done()
+
+			prompts, err := h.fetchPromptsFromAdapter(ctx, adapter)
+			if err != nil {
+				logging.ProxyLogger.Warn("UnifiedMCP: Failed to fetch prompts from %s: %v", adapter.Name, err)
+				return
+			}
+
+			// Prefix prompt names with adapter name
+			mu.Lock()
+			for _, prompt := range prompts {
+				prefixedPrompt := Prompt{
+					Name:        adapter.Name + "__" + prompt.Name,
+					Description: fmt.Sprintf("[%s] %s", adapter.Name, prompt.Description),
+					Arguments:   prompt.Arguments,
+				}
+				allPrompts = append(allPrompts, prefixedPrompt)
+			}
+			mu.Unlock()
+		}(adapter)
+	}
+
+	wg.Wait()
+
+	return &MCPResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  PromptsListResult{Prompts: allPrompts},
+	}
+}
+
+// handlePromptsGet routes a prompt get to the appropriate adapter
+func (h *UnifiedMCPHandler) handlePromptsGet(ctx context.Context, req *MCPRequest, userID string, headers http.Header) *MCPResponse {
+	// Parse params to get prompt name
+	paramsJSON, err := json.Marshal(req.Params)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Invalid params"},
+		}
+	}
+
+	var params struct {
+		Name      string                 `json:"name"`
+		Arguments map[string]interface{} `json:"arguments,omitempty"`
+	}
+	if err := json.Unmarshal(paramsJSON, &params); err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Invalid params: " + err.Error()},
+		}
+	}
+
+	// Extract adapter prefix from prompt name (format: adapter__promptname)
+	parts := strings.SplitN(params.Name, "__", 2)
+	if len(parts) != 2 {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Prompt name must be prefixed with adapter name"},
+		}
+	}
+
+	adapterName := parts[0]
+	promptName := parts[1]
+
+	// Get the adapter
+	adapter, err := h.adapterService.GetAdapter(ctx, userID, adapterName, h.userGroupService)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Adapter not found: " + adapterName},
+		}
+	}
+
+	// Forward the request with unprefixed prompt name
+	unprefixedReq := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Method:  "prompts/get",
+		Params: map[string]interface{}{
+			"name":      promptName,
+			"arguments": params.Arguments,
+		},
+	}
+
+	return h.forwardToAdapter(ctx, adapter, &unprefixedReq, headers)
+}
+
+// fetchToolsFromAdapter fetches tools from a single adapter
+func (h *UnifiedMCPHandler) fetchToolsFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Tool, error) {
+	req := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/list",
+		Params:  map[string]interface{}{},
+	}
+
+	resp, err := h.makeAdapterRequest(ctx, adapter.RemoteUrl, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("adapter error: %s", resp.Error.Message)
+	}
+
+	// Parse result
+	resultJSON, err := json.Marshal(resp.Result)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ToolsListResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Tools, nil
+}
+
+// fetchResourcesFromAdapter fetches resources from a single adapter
+func (h *UnifiedMCPHandler) fetchResourcesFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Resource, error) {
+	req := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "resources/list",
+		Params:  map[string]interface{}{},
+	}
+
+	resp, err := h.makeAdapterRequest(ctx, adapter.RemoteUrl, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("adapter error: %s", resp.Error.Message)
+	}
+
+	// Parse result
+	resultJSON, err := json.Marshal(resp.Result)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ResourcesListResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Resources, nil
+}
+
+// fetchPromptsFromAdapter fetches prompts from a single adapter
+func (h *UnifiedMCPHandler) fetchPromptsFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Prompt, error) {
+	req := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "prompts/list",
+		Params:  map[string]interface{}{},
+	}
+
+	resp, err := h.makeAdapterRequest(ctx, adapter.RemoteUrl, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("adapter error: %s", resp.Error.Message)
+	}
+
+	// Parse result
+	resultJSON, err := json.Marshal(resp.Result)
+	if err != nil {
+		return nil, err
+	}
+
+	var result PromptsListResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Prompts, nil
+}
+
+// makeAdapterRequest makes an HTTP request to an adapter
+func (h *UnifiedMCPHandler) makeAdapterRequest(ctx context.Context, url string, req *MCPRequest) (*MCPResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var mcpResp MCPResponse
+	if err := json.Unmarshal(respBody, &mcpResp); err != nil {
+		return nil, err
+	}
+
+	return &mcpResp, nil
+}
+
+// forwardToAdapter forwards a request to a specific adapter
+func (h *UnifiedMCPHandler) forwardToAdapter(ctx context.Context, adapter *models.AdapterResource, req *MCPRequest, headers http.Header) *MCPResponse {
+	if adapter.RemoteUrl == "" {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32602, Message: "Adapter has no remote URL"},
+		}
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Failed to marshal request"},
+		}
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, adapter.RemoteUrl, bytes.NewReader(body))
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Failed to create request"},
+		}
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	// Forward relevant headers
+	if userID := headers.Get("X-User-ID"); userID != "" {
+		httpReq.Header.Set("X-User-ID", userID)
+	}
+
+	resp, err := h.httpClient.Do(httpReq)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Failed to contact adapter: " + err.Error()},
+		}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Failed to read response"},
+		}
+	}
+
+	var mcpResp MCPResponse
+	if err := json.Unmarshal(respBody, &mcpResp); err != nil {
+		return &MCPResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &MCPRPCError{Code: -32603, Message: "Invalid response from adapter"},
+		}
+	}
+
+	return &mcpResp
+}
+
+// sendError sends an error response
+func (h *UnifiedMCPHandler) sendError(w http.ResponseWriter, id interface{}, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(MCPResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &MCPRPCError{Code: code, Message: message},
+	})
+}

--- a/internal/handlers/unified_mcp.go
+++ b/internal/handlers/unified_mcp.go
@@ -539,7 +539,9 @@ func (h *UnifiedMCPHandler) handlePromptsGet(ctx context.Context, req *MCPReques
 	return h.forwardToAdapter(ctx, adapter, &unprefixedReq, headers)
 }
 
-// fetchToolsFromAdapter fetches tools from a single adapter
+// fetchToolsFromAdapter fetches the list of available tools from a single remote MCP adapter.
+// It sends a tools/list JSON-RPC request to the adapter's remote URL and parses the response.
+// Returns the list of tools or an error if the request fails or the adapter returns an error.
 func (h *UnifiedMCPHandler) fetchToolsFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Tool, error) {
 	req := MCPRequest{
 		JSONRPC: "2.0",
@@ -571,7 +573,9 @@ func (h *UnifiedMCPHandler) fetchToolsFromAdapter(ctx context.Context, adapter m
 	return result.Tools, nil
 }
 
-// fetchResourcesFromAdapter fetches resources from a single adapter
+// fetchResourcesFromAdapter fetches the list of available resources from a single remote MCP adapter.
+// It sends a resources/list JSON-RPC request to the adapter's remote URL and parses the response.
+// Returns the list of resources or an error if the request fails or the adapter returns an error.
 func (h *UnifiedMCPHandler) fetchResourcesFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Resource, error) {
 	req := MCPRequest{
 		JSONRPC: "2.0",
@@ -603,7 +607,9 @@ func (h *UnifiedMCPHandler) fetchResourcesFromAdapter(ctx context.Context, adapt
 	return result.Resources, nil
 }
 
-// fetchPromptsFromAdapter fetches prompts from a single adapter
+// fetchPromptsFromAdapter fetches the list of available prompts from a single remote MCP adapter.
+// It sends a prompts/list JSON-RPC request to the adapter's remote URL and parses the response.
+// Returns the list of prompts or an error if the request fails or the adapter returns an error.
 func (h *UnifiedMCPHandler) fetchPromptsFromAdapter(ctx context.Context, adapter models.AdapterResource) ([]Prompt, error) {
 	req := MCPRequest{
 		JSONRPC: "2.0",
@@ -635,7 +641,10 @@ func (h *UnifiedMCPHandler) fetchPromptsFromAdapter(ctx context.Context, adapter
 	return result.Prompts, nil
 }
 
-// makeAdapterRequest makes an HTTP request to an adapter
+// makeAdapterRequest makes a JSON-RPC HTTP POST request to a remote MCP adapter.
+// It marshals the request to JSON, sends it to the specified URL, and parses the response.
+// The request is made with the context for cancellation and timeout support.
+// Returns the parsed MCP response or an error if the HTTP request or JSON parsing fails.
 func (h *UnifiedMCPHandler) makeAdapterRequest(ctx context.Context, url string, req *MCPRequest) (*MCPResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -668,7 +677,10 @@ func (h *UnifiedMCPHandler) makeAdapterRequest(ctx context.Context, url string, 
 	return &mcpResp, nil
 }
 
-// forwardToAdapter forwards a request to a specific adapter
+// forwardToAdapter forwards a JSON-RPC request to a specific remote MCP adapter and returns the response.
+// It handles the HTTP communication, including forwarding relevant headers (like X-User-ID) to the adapter.
+// If the adapter has no remote URL or communication fails, it returns an appropriate error response.
+// This is used by tools/call, resources/read, and prompts/get to route requests to the correct adapter.
 func (h *UnifiedMCPHandler) forwardToAdapter(ctx context.Context, adapter *models.AdapterResource, req *MCPRequest, headers http.Header) *MCPResponse {
 	if adapter.RemoteUrl == "" {
 		return &MCPResponse{
@@ -733,7 +745,11 @@ func (h *UnifiedMCPHandler) forwardToAdapter(ctx context.Context, adapter *model
 	return &mcpResp
 }
 
-// sendError sends an error response
+// sendError writes a JSON-RPC error response to the HTTP response writer.
+// It sets the Content-Type header to application/json and encodes an MCPResponse
+// with the specified error code and message. Standard JSON-RPC error codes include:
+// -32700 (Parse error), -32600 (Invalid request), -32601 (Method not found),
+// -32602 (Invalid params), -32603 (Internal error).
 func (h *UnifiedMCPHandler) sendError(w http.ResponseWriter, id interface{}, code int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(MCPResponse{

--- a/internal/handlers/unified_mcp_test.go
+++ b/internal/handlers/unified_mcp_test.go
@@ -1,0 +1,842 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"suse-ai-up/pkg/models"
+	"suse-ai-up/pkg/services"
+	adaptersvc "suse-ai-up/pkg/services/adapters"
+)
+
+// mockAdapterService implements the methods used by UnifiedMCPHandler
+type mockAdapterService struct {
+	adapters map[string]*models.AdapterResource
+}
+
+func newMockAdapterService() *mockAdapterService {
+	return &mockAdapterService{
+		adapters: make(map[string]*models.AdapterResource),
+	}
+}
+
+func (m *mockAdapterService) addAdapter(adapter *models.AdapterResource) {
+	m.adapters[adapter.Name] = adapter
+}
+
+// mockUserGroupService is a minimal mock for UserGroupService
+type mockUserGroupService struct{}
+
+// Helper to create a test handler with mock services
+func newTestUnifiedMCPHandler(adapters []*models.AdapterResource, mockServer *httptest.Server) *UnifiedMCPHandler {
+	mock := newMockAdapterService()
+	for _, a := range adapters {
+		if mockServer != nil && a.RemoteUrl == "" {
+			a.RemoteUrl = mockServer.URL
+		}
+		mock.addAdapter(a)
+	}
+
+	// Create a real handler but we'll need to work around the service dependency
+	// For now, we test the handler methods that don't require full service integration
+	handler := &UnifiedMCPHandler{
+		httpClient: http.DefaultClient,
+	}
+
+	return handler
+}
+
+// TestHandleUnifiedMCP_MethodNotAllowed tests that non-POST requests are rejected
+func TestHandleUnifiedMCP_MethodNotAllowed(t *testing.T) {
+	handler := &UnifiedMCPHandler{
+		httpClient: http.DefaultClient,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleUnifiedMCP(w, req)
+
+	var resp MCPResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.Error == nil {
+		t.Fatal("Expected error response for GET request")
+	}
+
+	if resp.Error.Code != -32600 {
+		t.Errorf("Expected error code -32600, got %d", resp.Error.Code)
+	}
+
+	if resp.Error.Message != "Only POST method is supported" {
+		t.Errorf("Unexpected error message: %s", resp.Error.Message)
+	}
+}
+
+// TestHandleUnifiedMCP_InvalidJSON tests that invalid JSON is rejected
+func TestHandleUnifiedMCP_InvalidJSON(t *testing.T) {
+	handler := &UnifiedMCPHandler{
+		httpClient: http.DefaultClient,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp", bytes.NewReader([]byte("invalid json")))
+	w := httptest.NewRecorder()
+
+	handler.HandleUnifiedMCP(w, req)
+
+	var resp MCPResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.Error == nil {
+		t.Fatal("Expected error response for invalid JSON")
+	}
+
+	if resp.Error.Code != -32700 {
+		t.Errorf("Expected error code -32700 (parse error), got %d", resp.Error.Code)
+	}
+}
+
+// TestHandleUnifiedMCP_UnknownMethod tests that unknown methods return method not found
+func TestHandleUnifiedMCP_UnknownMethod(t *testing.T) {
+	handler := &UnifiedMCPHandler{
+		httpClient: http.DefaultClient,
+	}
+
+	mcpReq := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "unknown/method",
+	}
+
+	body, _ := json.Marshal(mcpReq)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handler.HandleUnifiedMCP(w, req)
+
+	var resp MCPResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.Error == nil {
+		t.Fatal("Expected error response for unknown method")
+	}
+
+	if resp.Error.Code != -32601 {
+		t.Errorf("Expected error code -32601 (method not found), got %d", resp.Error.Code)
+	}
+}
+
+// TestHandleInitialize tests the initialize method
+func TestHandleInitialize(t *testing.T) {
+	handler := &UnifiedMCPHandler{
+		httpClient: http.DefaultClient,
+	}
+
+	mcpReq := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+	}
+
+	resp := handler.handleInitialize(context.Background(), &mcpReq)
+
+	if resp.Error != nil {
+		t.Fatalf("Unexpected error: %v", resp.Error)
+	}
+
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("Expected JSONRPC 2.0, got %s", resp.JSONRPC)
+	}
+
+	if resp.ID != 1 {
+		t.Errorf("Expected ID 1, got %v", resp.ID)
+	}
+
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected result to be map, got %T", resp.Result)
+	}
+
+	if result["protocolVersion"] != "2025-06-18" {
+		t.Errorf("Expected protocol version 2025-06-18, got %v", result["protocolVersion"])
+	}
+
+	serverInfo, ok := result["serverInfo"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected serverInfo in result")
+	}
+
+	if serverInfo["name"] != "suse-ai-unified-proxy" {
+		t.Errorf("Expected server name 'suse-ai-unified-proxy', got %v", serverInfo["name"])
+	}
+
+	capabilities, ok := result["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected capabilities in result")
+	}
+
+	if _, hasTools := capabilities["tools"]; !hasTools {
+		t.Error("Expected 'tools' capability")
+	}
+	if _, hasResources := capabilities["resources"]; !hasResources {
+		t.Error("Expected 'resources' capability")
+	}
+	if _, hasPrompts := capabilities["prompts"]; !hasPrompts {
+		t.Error("Expected 'prompts' capability")
+	}
+}
+
+// TestToolNameParsing tests that tool names are correctly parsed
+func TestToolNameParsing(t *testing.T) {
+	tests := []struct {
+		name          string
+		toolName      string
+		expectError   bool
+		expectedAdapter string
+		expectedTool  string
+	}{
+		{
+			name:          "valid tool name",
+			toolName:      "servicenow__get_incident",
+			expectError:   false,
+			expectedAdapter: "servicenow",
+			expectedTool:  "get_incident",
+		},
+		{
+			name:          "tool name with multiple underscores",
+			toolName:      "my_adapter__my_tool_name",
+			expectError:   false,
+			expectedAdapter: "my_adapter",
+			expectedTool:  "my_tool_name",
+		},
+		{
+			name:        "invalid tool name - no prefix",
+			toolName:    "get_incident",
+			expectError: true,
+		},
+		{
+			name:        "invalid tool name - single underscore",
+			toolName:    "servicenow_get_incident",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate the parsing logic from handleToolsCall
+			parts := splitToolName(tc.toolName)
+
+			if tc.expectError {
+				if len(parts) == 2 {
+					t.Errorf("Expected parsing to fail for %s, but got adapter=%s, tool=%s",
+						tc.toolName, parts[0], parts[1])
+				}
+			} else {
+				if len(parts) != 2 {
+					t.Fatalf("Expected parsing to succeed for %s", tc.toolName)
+				}
+				if parts[0] != tc.expectedAdapter {
+					t.Errorf("Expected adapter %s, got %s", tc.expectedAdapter, parts[0])
+				}
+				if parts[1] != tc.expectedTool {
+					t.Errorf("Expected tool %s, got %s", tc.expectedTool, parts[1])
+				}
+			}
+		})
+	}
+}
+
+// splitToolName is a helper that mirrors the parsing logic in handleToolsCall
+func splitToolName(name string) []string {
+	for i := 0; i < len(name)-1; i++ {
+		if name[i] == '_' && name[i+1] == '_' {
+			return []string{name[:i], name[i+2:]}
+		}
+	}
+	return nil
+}
+
+// TestResourceURIParsing tests that resource URIs are correctly parsed
+func TestResourceURIParsing(t *testing.T) {
+	tests := []struct {
+		name            string
+		uri             string
+		expectError     bool
+		expectedAdapter string
+		expectedURI     string
+	}{
+		{
+			name:            "valid URI",
+			uri:             "servicenow://incident/INC0001",
+			expectError:     false,
+			expectedAdapter: "servicenow",
+			expectedURI:     "incident/INC0001",
+		},
+		{
+			name:            "URI with nested path",
+			uri:             "databricks://clusters/metrics/cpu",
+			expectError:     false,
+			expectedAdapter: "databricks",
+			expectedURI:     "clusters/metrics/cpu",
+		},
+		{
+			name:        "invalid URI - no scheme",
+			uri:         "incident/INC0001",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate the parsing logic from handleResourcesRead
+			parts := splitResourceURI(tc.uri)
+
+			if tc.expectError {
+				if len(parts) == 2 {
+					t.Errorf("Expected parsing to fail for %s", tc.uri)
+				}
+			} else {
+				if len(parts) != 2 {
+					t.Fatalf("Expected parsing to succeed for %s", tc.uri)
+				}
+				if parts[0] != tc.expectedAdapter {
+					t.Errorf("Expected adapter %s, got %s", tc.expectedAdapter, parts[0])
+				}
+				if parts[1] != tc.expectedURI {
+					t.Errorf("Expected URI %s, got %s", tc.expectedURI, parts[1])
+				}
+			}
+		})
+	}
+}
+
+// splitResourceURI is a helper that mirrors the parsing logic in handleResourcesRead
+func splitResourceURI(uri string) []string {
+	for i := 0; i < len(uri)-2; i++ {
+		if uri[i] == ':' && uri[i+1] == '/' && uri[i+2] == '/' {
+			return []string{uri[:i], uri[i+3:]}
+		}
+	}
+	return nil
+}
+
+// TestToolPrefixing tests that tools are correctly prefixed with adapter name
+func TestToolPrefixing(t *testing.T) {
+	adapterName := "servicenow"
+	originalTool := Tool{
+		Name:        "get_incident",
+		Description: "Get incident details",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"incident_id": map[string]interface{}{
+					"type":        "string",
+					"description": "The incident ID",
+				},
+			},
+		},
+	}
+
+	// Simulate prefixing logic from handleToolsList
+	prefixedTool := Tool{
+		Name:        adapterName + "__" + originalTool.Name,
+		Description: "[" + adapterName + "] " + originalTool.Description,
+		InputSchema: originalTool.InputSchema,
+	}
+
+	expectedName := "servicenow__get_incident"
+	expectedDesc := "[servicenow] Get incident details"
+
+	if prefixedTool.Name != expectedName {
+		t.Errorf("Expected name %s, got %s", expectedName, prefixedTool.Name)
+	}
+
+	if prefixedTool.Description != expectedDesc {
+		t.Errorf("Expected description %s, got %s", expectedDesc, prefixedTool.Description)
+	}
+}
+
+// TestResourcePrefixing tests that resources are correctly prefixed with adapter scheme
+func TestResourcePrefixing(t *testing.T) {
+	adapterName := "servicenow"
+	originalResource := Resource{
+		URI:         "incident/INC0001",
+		Name:        "Incident INC0001",
+		Description: "Details for incident INC0001",
+		MimeType:    "application/json",
+	}
+
+	// Simulate prefixing logic from handleResourcesList
+	prefixedResource := Resource{
+		URI:         adapterName + "://" + originalResource.URI,
+		Name:        "[" + adapterName + "] " + originalResource.Name,
+		Description: originalResource.Description,
+		MimeType:    originalResource.MimeType,
+	}
+
+	expectedURI := "servicenow://incident/INC0001"
+	expectedName := "[servicenow] Incident INC0001"
+
+	if prefixedResource.URI != expectedURI {
+		t.Errorf("Expected URI %s, got %s", expectedURI, prefixedResource.URI)
+	}
+
+	if prefixedResource.Name != expectedName {
+		t.Errorf("Expected name %s, got %s", expectedName, prefixedResource.Name)
+	}
+}
+
+// TestPromptPrefixing tests that prompts are correctly prefixed with adapter name
+func TestPromptPrefixing(t *testing.T) {
+	adapterName := "servicenow"
+	originalPrompt := Prompt{
+		Name:        "create_incident",
+		Description: "Create a new incident",
+		Arguments:   []interface{}{"title", "description", "priority"},
+	}
+
+	// Simulate prefixing logic from handlePromptsList
+	prefixedPrompt := Prompt{
+		Name:        adapterName + "__" + originalPrompt.Name,
+		Description: "[" + adapterName + "] " + originalPrompt.Description,
+		Arguments:   originalPrompt.Arguments,
+	}
+
+	expectedName := "servicenow__create_incident"
+	expectedDesc := "[servicenow] Create a new incident"
+
+	if prefixedPrompt.Name != expectedName {
+		t.Errorf("Expected name %s, got %s", expectedName, prefixedPrompt.Name)
+	}
+
+	if prefixedPrompt.Description != expectedDesc {
+		t.Errorf("Expected description %s, got %s", expectedDesc, prefixedPrompt.Description)
+	}
+}
+
+// TestMCPResponseSerialization tests that MCP responses are correctly serialized
+func TestMCPResponseSerialization(t *testing.T) {
+	tests := []struct {
+		name     string
+		response MCPResponse
+	}{
+		{
+			name: "success response",
+			response: MCPResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Result:  ToolsListResult{Tools: []Tool{{Name: "test_tool"}}},
+			},
+		},
+		{
+			name: "error response",
+			response: MCPResponse{
+				JSONRPC: "2.0",
+				ID:      1,
+				Error:   &MCPRPCError{Code: -32600, Message: "Invalid request"},
+			},
+		},
+		{
+			name: "response with null ID",
+			response: MCPResponse{
+				JSONRPC: "2.0",
+				ID:      nil,
+				Error:   &MCPRPCError{Code: -32700, Message: "Parse error"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.response)
+			if err != nil {
+				t.Fatalf("Failed to marshal response: %v", err)
+			}
+
+			var decoded MCPResponse
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("Failed to unmarshal response: %v", err)
+			}
+
+			if decoded.JSONRPC != tc.response.JSONRPC {
+				t.Errorf("JSONRPC mismatch: expected %s, got %s", tc.response.JSONRPC, decoded.JSONRPC)
+			}
+		})
+	}
+}
+
+// TestSendError tests the sendError helper function
+func TestSendError(t *testing.T) {
+	handler := &UnifiedMCPHandler{}
+
+	w := httptest.NewRecorder()
+	handler.sendError(w, 123, -32600, "Test error message")
+
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Expected Content-Type application/json, got %s", w.Header().Get("Content-Type"))
+	}
+
+	var resp MCPResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("Expected JSONRPC 2.0, got %s", resp.JSONRPC)
+	}
+
+	// ID should be 123 (as float64 after JSON round-trip)
+	if resp.ID != float64(123) {
+		t.Errorf("Expected ID 123, got %v", resp.ID)
+	}
+
+	if resp.Error == nil {
+		t.Fatal("Expected error in response")
+	}
+
+	if resp.Error.Code != -32600 {
+		t.Errorf("Expected error code -32600, got %d", resp.Error.Code)
+	}
+
+	if resp.Error.Message != "Test error message" {
+		t.Errorf("Expected error message 'Test error message', got %s", resp.Error.Message)
+	}
+}
+
+// TestIntegration_ToolsListWithMockAdapter tests tools/list with a mock MCP adapter
+func TestIntegration_ToolsListWithMockAdapter(t *testing.T) {
+	// Create a mock MCP server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req MCPRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Mock server failed to decode request: %v", err)
+			return
+		}
+
+		if req.Method == "tools/list" {
+			resp := MCPResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: ToolsListResult{
+					Tools: []Tool{
+						{Name: "get_incident", Description: "Get incident details"},
+						{Name: "list_incidents", Description: "List all incidents"},
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Create handler with mock HTTP client
+	handler := &UnifiedMCPHandler{
+		httpClient: mockServer.Client(),
+	}
+
+	// Test fetchToolsFromAdapter directly
+	adapter := models.AdapterResource{
+		AdapterData: models.AdapterData{
+			Name:           "servicenow",
+			ConnectionType: models.ConnectionTypeRemoteHttp,
+			RemoteUrl:      mockServer.URL,
+		},
+	}
+
+	tools, err := handler.fetchToolsFromAdapter(context.Background(), adapter)
+	if err != nil {
+		t.Fatalf("fetchToolsFromAdapter failed: %v", err)
+	}
+
+	if len(tools) != 2 {
+		t.Errorf("Expected 2 tools, got %d", len(tools))
+	}
+
+	if tools[0].Name != "get_incident" {
+		t.Errorf("Expected first tool name 'get_incident', got %s", tools[0].Name)
+	}
+}
+
+// TestIntegration_ResourcesListWithMockAdapter tests resources/list with a mock MCP adapter
+func TestIntegration_ResourcesListWithMockAdapter(t *testing.T) {
+	// Create a mock MCP server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req MCPRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Mock server failed to decode request: %v", err)
+			return
+		}
+
+		if req.Method == "resources/list" {
+			resp := MCPResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: ResourcesListResult{
+					Resources: []Resource{
+						{URI: "incident/INC0001", Name: "Incident INC0001", MimeType: "application/json"},
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	defer mockServer.Close()
+
+	handler := &UnifiedMCPHandler{
+		httpClient: mockServer.Client(),
+	}
+
+	adapter := models.AdapterResource{
+		AdapterData: models.AdapterData{
+			Name:           "servicenow",
+			ConnectionType: models.ConnectionTypeRemoteHttp,
+			RemoteUrl:      mockServer.URL,
+		},
+	}
+
+	resources, err := handler.fetchResourcesFromAdapter(context.Background(), adapter)
+	if err != nil {
+		t.Fatalf("fetchResourcesFromAdapter failed: %v", err)
+	}
+
+	if len(resources) != 1 {
+		t.Errorf("Expected 1 resource, got %d", len(resources))
+	}
+
+	if resources[0].URI != "incident/INC0001" {
+		t.Errorf("Expected resource URI 'incident/INC0001', got %s", resources[0].URI)
+	}
+}
+
+// TestIntegration_PromptsListWithMockAdapter tests prompts/list with a mock MCP adapter
+func TestIntegration_PromptsListWithMockAdapter(t *testing.T) {
+	// Create a mock MCP server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req MCPRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Mock server failed to decode request: %v", err)
+			return
+		}
+
+		if req.Method == "prompts/list" {
+			resp := MCPResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: PromptsListResult{
+					Prompts: []Prompt{
+						{Name: "create_incident", Description: "Create a new incident"},
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	defer mockServer.Close()
+
+	handler := &UnifiedMCPHandler{
+		httpClient: mockServer.Client(),
+	}
+
+	adapter := models.AdapterResource{
+		AdapterData: models.AdapterData{
+			Name:           "servicenow",
+			ConnectionType: models.ConnectionTypeRemoteHttp,
+			RemoteUrl:      mockServer.URL,
+		},
+	}
+
+	prompts, err := handler.fetchPromptsFromAdapter(context.Background(), adapter)
+	if err != nil {
+		t.Fatalf("fetchPromptsFromAdapter failed: %v", err)
+	}
+
+	if len(prompts) != 1 {
+		t.Errorf("Expected 1 prompt, got %d", len(prompts))
+	}
+
+	if prompts[0].Name != "create_incident" {
+		t.Errorf("Expected prompt name 'create_incident', got %s", prompts[0].Name)
+	}
+}
+
+// TestForwardToAdapter_NoRemoteURL tests forwarding when adapter has no remote URL
+func TestForwardToAdapter_NoRemoteURL(t *testing.T) {
+	handler := &UnifiedMCPHandler{
+		httpClient: http.DefaultClient,
+	}
+
+	adapter := &models.AdapterResource{
+		AdapterData: models.AdapterData{
+			Name:      "test-adapter",
+			RemoteUrl: "",
+		},
+	}
+
+	req := &MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+	}
+
+	resp := handler.forwardToAdapter(context.Background(), adapter, req, http.Header{})
+
+	if resp.Error == nil {
+		t.Fatal("Expected error for adapter with no remote URL")
+	}
+
+	if resp.Error.Code != -32602 {
+		t.Errorf("Expected error code -32602, got %d", resp.Error.Code)
+	}
+
+	if resp.Error.Message != "Adapter has no remote URL" {
+		t.Errorf("Unexpected error message: %s", resp.Error.Message)
+	}
+}
+
+// TestForwardToAdapter_HeaderForwarding tests that X-User-ID header is forwarded
+func TestForwardToAdapter_HeaderForwarding(t *testing.T) {
+	receivedHeaders := make(http.Header)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture received headers
+		for k, v := range r.Header {
+			receivedHeaders[k] = v
+		}
+
+		resp := MCPResponse{
+			JSONRPC: "2.0",
+			ID:      1,
+			Result:  map[string]interface{}{"success": true},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	handler := &UnifiedMCPHandler{
+		httpClient: mockServer.Client(),
+	}
+
+	adapter := &models.AdapterResource{
+		AdapterData: models.AdapterData{
+			Name:      "test-adapter",
+			RemoteUrl: mockServer.URL,
+		},
+	}
+
+	req := &MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+	}
+
+	headers := http.Header{}
+	headers.Set("X-User-ID", "test-user-123")
+
+	resp := handler.forwardToAdapter(context.Background(), adapter, req, headers)
+
+	if resp.Error != nil {
+		t.Fatalf("Unexpected error: %v", resp.Error)
+	}
+
+	if receivedHeaders.Get("X-User-ID") != "test-user-123" {
+		t.Errorf("Expected X-User-ID header to be forwarded, got %s", receivedHeaders.Get("X-User-ID"))
+	}
+
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("Expected Content-Type header, got %s", receivedHeaders.Get("Content-Type"))
+	}
+}
+
+// TestMakeAdapterRequest_Success tests successful adapter request
+func TestMakeAdapterRequest_Success(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := MCPResponse{
+			JSONRPC: "2.0",
+			ID:      1,
+			Result:  ToolsListResult{Tools: []Tool{{Name: "test_tool"}}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	handler := &UnifiedMCPHandler{
+		httpClient: mockServer.Client(),
+	}
+
+	req := &MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/list",
+	}
+
+	resp, err := handler.makeAdapterRequest(context.Background(), mockServer.URL, req)
+	if err != nil {
+		t.Fatalf("makeAdapterRequest failed: %v", err)
+	}
+
+	if resp.Error != nil {
+		t.Fatalf("Unexpected error in response: %v", resp.Error)
+	}
+
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("Expected JSONRPC 2.0, got %s", resp.JSONRPC)
+	}
+}
+
+// TestMakeAdapterRequest_AdapterError tests handling of adapter error responses
+func TestMakeAdapterRequest_AdapterError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := MCPResponse{
+			JSONRPC: "2.0",
+			ID:      1,
+			Error:   &MCPRPCError{Code: -32603, Message: "Internal error"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	handler := &UnifiedMCPHandler{
+		httpClient: mockServer.Client(),
+	}
+
+	req := &MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/list",
+	}
+
+	resp, err := handler.makeAdapterRequest(context.Background(), mockServer.URL, req)
+	if err != nil {
+		t.Fatalf("makeAdapterRequest failed: %v", err)
+	}
+
+	if resp.Error == nil {
+		t.Fatal("Expected error in response")
+	}
+
+	if resp.Error.Code != -32603 {
+		t.Errorf("Expected error code -32603, got %d", resp.Error.Code)
+	}
+}
+
+// Ensure imports are used (they are used in the mocks at the top)
+var (
+	_ *adaptersvc.AdapterService
+	_ *services.UserGroupService
+)


### PR DESCRIPTION
## Summary                                                                                                                                                                      
  - Add `/api/v1/mcp` endpoint that aggregates tools, resources, and prompts from all registered adapters into a single MCP interface                                             
  - Tool names prefixed with adapter name (e.g., `servicenow__get_incident`) and calls routed to the correct backend adapter                                                      
  - Resource URIs prefixed with adapter scheme (e.g., `servicenow://incident/INC0001`)                                                                                            
  - Include ServiceNow + Databricks incident correlation demo showcasing the unified endpoint                                                                                     
                                                                                                                                                                                  
  ## Changes                                                                                                                                                                      
  - `internal/handlers/unified_mcp.go` - Unified MCP handler implementation                                                                                                       
  - `internal/handlers/unified_mcp_test.go` - Unit tests (misc tests covering parsing, prefixing, error handling, and mock adapter integration)                                     
  - `cmd/uniproxy/main.go` - Route registration                                                                                                                                   
  - `examples/servicenow-databricks-demo/` - Demo with Kubernetes (kustomize) and Docker Compose configs                                                                          
 